### PR TITLE
Raise exceptions on read and write instead of returning error tuples

### DIFF
--- a/lib/gpio.ex
+++ b/lib/gpio.ex
@@ -21,7 +21,7 @@ defmodule ElixirCircuits.GPIO do
   @doc """
   Read the current value on a pin.
   """
-  @spec read(reference()) :: value() | {:error, atom()}
+  @spec read(reference()) :: value()
   def read(gpio) do
     Nif.read(gpio)
   end
@@ -30,7 +30,7 @@ defmodule ElixirCircuits.GPIO do
   Set the value of a pin. The pin should be configured to an output
   for this to work.
   """
-  @spec write(reference(), value()) :: :ok | {:error, atom()}
+  @spec write(reference(), value()) :: :ok
   def write(gpio, value) do
     Nif.write(gpio, value)
   end
@@ -81,7 +81,7 @@ defmodule ElixirCircuits.GPIO do
   @doc """
   Get the GPIO pin number
   """
-  @spec pin(reference) :: pin_number | {:error, atom}
+  @spec pin(reference) :: pin_number
   def pin(gpio) do
     Nif.pin(gpio)
   end

--- a/src/gpio_nif.c
+++ b/src/gpio_nif.c
@@ -183,7 +183,7 @@ static void *gpio_poller_thread(void *arg)
     init_listeners(monitor_info);
     for (;;) {
         struct pollfd *fds = &fdset[0];
-        int count = 0;
+        nfds_t count = 0;
 
         struct gpio_monitor_info *info = monitor_info;
         while (info->fd >= 0) {
@@ -229,7 +229,7 @@ static void *gpio_poller_thread(void *arg)
         }
 
         bool cleanup = false;
-        for (int i = 0; i < count - 1; i++) {
+        for (nfds_t i = 0; i < count - 1; i++) {
             if (fdset[i].revents) {
                 if (fdset[i].revents & POLLPRI) {
                     int value = sysfs_read_gpio(fdset[i].fd);


### PR DESCRIPTION
The intention here is to simplify the API by removing the need for users to check for `{:error, reason}`. I can't think of any way that an error could occur that isn't a programming mistake (writing to an input) or something truly exceptional (someone unmounts the sysfs partition or loads a device tree overlay that changes the gpio).

Fixes #14.