### PR TITLE
allow specifying the receiver of notifications in GPIO.set_edge_mode

### DIFF
--- a/lib/gpio.ex
+++ b/lib/gpio.ex
@@ -63,10 +63,13 @@ defmodule Circuits.GPIO do
   @spec set_edge_mode(reference(), edge(), list()) :: :ok | {:error, atom()}
   def set_edge_mode(gpio, edge \\ :both, opts \\ []) do
     suppress_glitches = Keyword.get(opts, :suppress_glitches, true)
-    receiver = case Keyword.get(opts, :receiver) do
-                 pid when is_pid(pid) -> pid
-                 _ -> self()
-               end
+
+    receiver =
+      case Keyword.get(opts, :receiver) do
+        pid when is_pid(pid) -> pid
+        name when is_atom(name) -> Process.whereis(name) || self()
+        _ -> self()
+      end
 
     Nif.set_edge_mode(gpio, edge, suppress_glitches, receiver)
   end

--- a/lib/gpio.ex
+++ b/lib/gpio.ex
@@ -44,12 +44,10 @@ defmodule Circuits.GPIO do
   * :falling - Send a notification when the pin changes from 1 to 0
   * :both - Send a notification on all changes
 
-  It is possible that the pin transitions to a value and back by the time
-  that Circuits GPIO gets to process it.
-
   Available Options:
-  * `suppress_glitches` - controls whether a notification is sent.
-  Set this to `false` to receive notifications.
+  * `suppress_glitches` - It is possible that the pin transitions to a value
+  and back by the time that Circuits GPIO gets to process it. This controls
+  whether a notification is sent. Set this to `false` to receive notifications.
   * `receiver` - Process which should receive the notifications.
   Defaults to the calling process (`self()`)
 


### PR DESCRIPTION
I'm running into some cases where it might be more beneficial to specify a place _other_ than the calling process for the notification messages to be sent to. However, the current implementation hard-codes in `self()`.

As is, this is a breaking change. I went this route thinking that specifying a `receiver` pid and a `suppress_glitches` boolean as options might fit better since there probably won't be that much deviation. And then you don't have to write in all the defaults if you only want to change one of them down the line (i.e. `GPIO.set_edge_mode(4, :both, true, some_pid)` vs `GPIO.set_edge_mode(4, :both, receiver: some_pid`)

But really, its 6's. Could easily add in as just a fourth argument with a default of `self()` (and probably some validation to make sure a pid is used...)

Thoughts?