### PR TITLE
Rename set_edge_mode to set_interrupts

### DIFF
--- a/PORTING.md
+++ b/PORTING.md
@@ -43,7 +43,7 @@ The remain modifications should mostly be mechanical:
    While you're at it, review the arguments to open to not include any
    `GenServer` options.
 3. Change calls to `ElixirALE.GPIO.set_int/2` to
-   `Circuits.GPIO.set_edge_mode/2`.
+   `Circuits.GPIO.set_interrupts/3`.
 4. Change the pattern match for the GPIO interrupt events to match 4 tuples.
    They have the form `{:gpio, <pin_number>, <timestamp>, <value>}`
 5. Review calls to `write/2` to ensure that they pass `0` or `1`. `ElixirALE`

--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ iex> Circuits.GPIO.read(gpio)
 ```
 
 If you'd like to get a message when the button is pressed or released, call the
-`set_edge_mode` function. You can trigger on the `:rising` edge, `:falling` edge
+`set_interrupts` function. You can trigger on the `:rising` edge, `:falling` edge
 or `:both`.
 
 ```elixir
-iex> Circuits.GPIO.set_edge_mode(gpio, :both)
+iex> Circuits.GPIO.set_interrupts(gpio, :both)
 :ok
 
 iex> flush
@@ -101,7 +101,7 @@ iex> flush
 :ok
 ```
 
-Note that after calling `set_edge_mode`, the calling process will receive an
+Note that after calling `set_interrupts`, the calling process will receive an
 initial message with the state of the pin. This prevents the race condition
 between getting the initial state of the pin and turning on interrupts. Without
 it, you could get the state of the pin, it could change states, and then you

--- a/lib/gpio.ex
+++ b/lib/gpio.ex
@@ -4,7 +4,7 @@ defmodule Circuits.GPIO do
   @type pin_number :: non_neg_integer()
   @type pin_direction :: :input | :output
   @type value :: 0 | 1
-  @type edge :: :rising | :falling | :both | :none
+  @type trigger :: :rising | :falling | :both | :none
   @type pull_mode :: :not_set | :none | :pullup | :pulldown
 
   # Public API
@@ -48,7 +48,7 @@ defmodule Circuits.GPIO do
 
   @doc """
   Enable or disable pin value change notifications. The notifications
-  are sent based on the edge mode parameter:
+  are sent based on the trigger parameter:
 
   * :none - No notifications are sent
   * :rising - Send a notification when the pin changes from 0 to 1
@@ -71,8 +71,8 @@ defmodule Circuits.GPIO do
   Where `pin_number` is the pin that changed values, `timestamp` is roughly when
   the transition occurred in nanoseconds, and `value` is the new value.
   """
-  @spec set_edge_mode(reference(), edge(), list()) :: :ok | {:error, atom()}
-  def set_edge_mode(gpio, edge \\ :both, opts \\ []) do
+  @spec set_interrupts(reference(), trigger(), list()) :: :ok | {:error, atom()}
+  def set_interrupts(gpio, trigger, opts \\ []) do
     suppress_glitches = Keyword.get(opts, :suppress_glitches, true)
 
     receiver =
@@ -82,7 +82,7 @@ defmodule Circuits.GPIO do
         _ -> self()
       end
 
-    Nif.set_edge_mode(gpio, edge, suppress_glitches, receiver)
+    Nif.set_interrupts(gpio, trigger, suppress_glitches, receiver)
   end
 
   @doc """
@@ -125,9 +125,8 @@ defmodule Circuits.GPIO do
     defdelegate open(pin_number, pin_direction), to: Circuits.GPIO
     defdelegate read(gpio), to: Circuits.GPIO
     defdelegate write(gpio, value), to: Circuits.GPIO
-    defdelegate set_edge_mode(gpio), to: Circuits.GPIO
-    defdelegate set_edge_mode(gpio, edge), to: Circuits.GPIO
-    defdelegate set_edge_mode(gpio, edge, suppress_glitches), to: Circuits.GPIO
+    defdelegate set_interrupts(gpio, trigger), to: Circuits.GPIO
+    defdelegate set_interrupts(gpio, trigger, opts), to: Circuits.GPIO
     defdelegate set_direction(gpio, pin_direction), to: Circuits.GPIO
     defdelegate set_pull_mode(gpio, pull_mode), to: Circuits.GPIO
     defdelegate pin(gpio), to: Circuits.GPIO

--- a/lib/gpio/gpio_nif.ex
+++ b/lib/gpio/gpio_nif.ex
@@ -26,7 +26,7 @@ defmodule Circuits.GPIO.Nif do
     :erlang.nif_error(:nif_not_loaded)
   end
 
-  def set_edge_mode(_gpio, _edge, _suppress_glitches, _process) do
+  def set_interrupts(_gpio, _trigger, _suppress_glitches, _process) do
     :erlang.nif_error(:nif_not_loaded)
   end
 

--- a/src/gpio_nif.h
+++ b/src/gpio_nif.h
@@ -25,11 +25,11 @@
 
 #define MAX_GPIO_LISTENERS 32
 
-enum edge_mode {
-    EDGE_NONE,
-    EDGE_RISING,
-    EDGE_FALLING,
-    EDGE_BOTH
+enum trigger_mode {
+    TRIGGER_NONE,
+    TRIGGER_RISING,
+    TRIGGER_FALLING,
+    TRIGGER_BOTH
 };
 
 enum pull_mode {
@@ -51,7 +51,7 @@ struct gpio_priv {
 
 struct gpio_config {
     bool is_output;
-    enum edge_mode edge;
+    enum trigger_mode trigger;
     enum pull_mode pull;
     bool suppress_glitches;
     ErlNifPid pid;
@@ -141,12 +141,12 @@ int hal_write_gpio(struct gpio_pin *pin, int value, ErlNifEnv *env);
 int hal_apply_direction(struct gpio_pin *pin);
 
 /**
- * Apply GPIO change notification state
+ * Apply GPIO interrupt settings
  *
- * @param pin the pin and notification edge info
+ * @param pin the pin and notification trigger info
  * @return 0 on success
  */
-int hal_apply_edge_mode(struct gpio_pin *pin, ErlNifEnv *env);
+int hal_apply_interrupts(struct gpio_pin *pin, ErlNifEnv *env);
 
 /**
  * Apply GPIO pull mode settings

--- a/test/circuits_gpio_test.exs
+++ b/test/circuits_gpio_test.exs
@@ -107,11 +107,11 @@ defmodule Circuits.GPIOTest do
     GPIO.close(gpio)
   end
 
-  test "initial interrupt on set_edge_mode" do
+  test "initial interrupt on set_interrupts" do
     {:ok, gpio0} = GPIO.open(0, :output)
     {:ok, gpio1} = GPIO.open(1, :input)
 
-    :ok = GPIO.set_edge_mode(gpio1, :both)
+    :ok = GPIO.set_interrupts(gpio1, :both)
     assert_receive {:gpio, 1, _timestamp, 0}
 
     GPIO.close(gpio0)
@@ -122,7 +122,7 @@ defmodule Circuits.GPIOTest do
     {:ok, gpio0} = GPIO.open(0, :output)
     {:ok, gpio1} = GPIO.open(1, :input)
 
-    :ok = GPIO.set_edge_mode(gpio1, :both)
+    :ok = GPIO.set_interrupts(gpio1, :both)
     assert_receive {:gpio, 1, _timestamp, 0}
 
     :ok = GPIO.write(gpio0, 1)
@@ -139,7 +139,7 @@ defmodule Circuits.GPIOTest do
     {:ok, gpio0} = GPIO.open(0, :output)
     {:ok, gpio1} = GPIO.open(1, :input)
 
-    :ok = GPIO.set_edge_mode(gpio1, :falling)
+    :ok = GPIO.set_interrupts(gpio1, :falling)
     assert_receive {:gpio, 1, _timestamp, 0}
 
     :ok = GPIO.write(gpio0, 1)
@@ -156,7 +156,7 @@ defmodule Circuits.GPIOTest do
     {:ok, gpio0} = GPIO.open(0, :output)
     {:ok, gpio1} = GPIO.open(1, :input)
 
-    :ok = GPIO.set_edge_mode(gpio1, :rising)
+    :ok = GPIO.set_interrupts(gpio1, :rising)
     refute_receive {:gpio, 1, _timestamp, 0}
 
     :ok = GPIO.write(gpio0, 1)
@@ -173,13 +173,13 @@ defmodule Circuits.GPIOTest do
     {:ok, gpio0} = GPIO.open(0, :output)
     {:ok, gpio1} = GPIO.open(1, :input)
 
-    :ok = GPIO.set_edge_mode(gpio1, :both)
+    :ok = GPIO.set_interrupts(gpio1, :both)
     assert_receive {:gpio, 1, _timestamp, 0}
 
     :ok = GPIO.write(gpio0, 1)
     assert_receive {:gpio, 1, _timestamp, 1}
 
-    :ok = GPIO.set_edge_mode(gpio1, :none)
+    :ok = GPIO.set_interrupts(gpio1, :none)
     :ok = GPIO.write(gpio0, 0)
     refute_receive {:gpio, 1, _timestamp, 0}
 
@@ -191,7 +191,7 @@ defmodule Circuits.GPIOTest do
     {:ok, gpio0} = GPIO.open(0, :output)
     {:ok, gpio1} = GPIO.open(1, :input)
 
-    :ok = GPIO.set_edge_mode(gpio1, :both)
+    :ok = GPIO.set_interrupts(gpio1, :both)
     assert_receive {:gpio, 1, _timestamp, 0}
 
     :ok = GPIO.write(gpio0, 1)


### PR DESCRIPTION
This fixes #21. The desire is to improve the name of the function to
make it more obvious what it does (i.e. configure the sending of
messages when the line changes state). See the issue for the discussion.