### PR TITLE
Support glitch-free output initialization

### DIFF
--- a/lib/gpio.ex
+++ b/lib/gpio.ex
@@ -10,12 +10,21 @@ defmodule Circuits.GPIO do
   # Public API
 
   @doc """
-  Open a GPIO for use. `pin` should be a valid GPIO pin number on the system
-  and `pin_direction` should be `:input` or `:output`.
+  Open a GPIO for use.
+
+  `pin` should be a valid GPIO pin number on the system and `pin_direction`
+  should be `:input` or `:output`. If opening as an output, then be sure to set
+  the `:initial_value` option if you need the set to be glitch free.
+
+  Options:
+
+  * :initial_value - Set to `:not_set`, `0` or `1` if this is an output.
+    `:not_set` is the default.
   """
-  @spec open(pin_number(), pin_direction()) :: {:ok, reference()} | {:error, atom()}
-  def open(pin_number, pin_direction) do
-    Nif.open(pin_number, pin_direction)
+  @spec open(pin_number(), pin_direction(), keyword()) :: {:ok, reference()} | {:error, atom()}
+  def open(pin_number, pin_direction, options \\ []) do
+    value = Keyword.get(options, :initial_value, :not_set)
+    Nif.open(pin_number, pin_direction, value)
   end
 
   @doc """

--- a/lib/gpio/gpio_nif.ex
+++ b/lib/gpio/gpio_nif.ex
@@ -10,7 +10,7 @@ defmodule Circuits.GPIO.Nif do
     :erlang.load_nif(to_charlist(nif_binary), 0)
   end
 
-  def open(_pin_number, _pin_direction) do
+  def open(_pin_number, _pin_direction, _initial_value) do
     :erlang.nif_error(:nif_not_loaded)
   end
 

--- a/src/gpio_nif.c
+++ b/src/gpio_nif.c
@@ -176,6 +176,19 @@ static int get_direction(ErlNifEnv *env, ERL_NIF_TERM term, bool *is_output)
     return true;
 }
 
+static int get_value(ErlNifEnv *env, ERL_NIF_TERM term, int *value)
+{
+    int v;
+    if (enif_get_int(env, term, &v)) {
+        // Force v to be 0 or 1
+        *value = !!v;
+    } else {
+        // Interpret anything else as ":not_set"
+        *value = -1;
+    }
+    return true;
+}
+
 static int get_pull_mode(ErlNifEnv *env, ERL_NIF_TERM term, enum pull_mode *pull)
 {
     char buffer[16];
@@ -275,9 +288,11 @@ static ERL_NIF_TERM open_gpio(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
 
     bool is_output;
     int pin_number;
-    if (argc != 2 ||
+    int initial_value;
+    if (argc != 3 ||
             !enif_get_int(env, argv[0], &pin_number) ||
-            !get_direction(env, argv[1], &is_output))
+            !get_direction(env, argv[1], &is_output) ||
+            !get_value(env, argv[2], &initial_value))
         return enif_make_badarg(env);
 
     struct gpio_pin *pin = enif_alloc_resource(priv->gpio_pin_rt, sizeof(struct gpio_pin));
@@ -288,6 +303,7 @@ static ERL_NIF_TERM open_gpio(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     pin->config.trigger = TRIGGER_NONE;
     pin->config.pull = PULL_NOT_SET;
     pin->config.suppress_glitches = false;
+    pin->config.initial_value = initial_value;
 
     char error_str[64];
     if (hal_open_gpio(pin, error_str, env) < 0) {
@@ -330,7 +346,7 @@ static ERL_NIF_TERM gpio_info(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
 }
 
 static ErlNifFunc nif_funcs[] = {
-    {"open", 2, open_gpio, ERL_NIF_DIRTY_JOB_IO_BOUND},
+    {"open", 3, open_gpio, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"close", 1, close_gpio, 0},
     {"read", 1, read_gpio, 0},
     {"write", 2, write_gpio, 0},

--- a/src/gpio_nif.h
+++ b/src/gpio_nif.h
@@ -54,6 +54,7 @@ struct gpio_config {
     enum trigger_mode trigger;
     enum pull_mode pull;
     bool suppress_glitches;
+    int initial_value;
     ErlNifPid pid;
 };
 
@@ -134,6 +135,12 @@ int hal_write_gpio(struct gpio_pin *pin, int value, ErlNifEnv *env);
 
 /**
  * Apply GPIO direction settings
+ *
+ * This should set the GPIO to an input or an output. If setting
+ * as an output, it should check the initial_value. If the
+ * initial_value is < 0 then the GPIO should retain its value
+ * if already an output. If set to 0 or 1, the GPIO should be
+ * initialized to that value.
  *
  * @param pin which one
  * @return 0 on success

--- a/src/hal_stub.c
+++ b/src/hal_stub.c
@@ -62,6 +62,10 @@ int hal_open_gpio(struct gpio_pin *pin,
     // For test purposes, pins 0-63 work and everything else fails
     if (pin->pin_number >= 0 && pin->pin_number < NUM_GPIOS) {
         pin->fd = pin->pin_number;
+
+        if (pin->config.is_output && pin->config.initial_value != -1)
+            hal_write_gpio(pin, pin->config.initial_value, env);
+
         *error_str = '\0';
         return 0;
     } else {

--- a/test/circuits_gpio_test.exs
+++ b/test/circuits_gpio_test.exs
@@ -205,4 +205,29 @@ defmodule Circuits.GPIOTest do
 
     GPIO.close(gpio0)
   end
+
+  test "opening as an output doesn't change the output by default" do
+    {:ok, gpio0} = GPIO.open(0, :output)
+    :ok = GPIO.write(gpio0, 1)
+    GPIO.close(gpio0)
+
+    {:ok, gpio0} = GPIO.open(0, :output)
+    assert GPIO.read(gpio0) == 1
+    :ok = GPIO.write(gpio0, 0)
+    GPIO.close(gpio0)
+
+    {:ok, gpio0} = GPIO.open(0, :output)
+    assert GPIO.read(gpio0) == 0
+    GPIO.close(gpio0)
+  end
+
+  test "can set the output on open" do
+    {:ok, gpio0} = GPIO.open(0, :output, initial_value: 1)
+    assert GPIO.read(gpio0) == 1
+    GPIO.close(gpio0)
+
+    {:ok, gpio0} = GPIO.open(0, :output, initial_value: 0)
+    assert GPIO.read(gpio0) == 0
+    GPIO.close(gpio0)
+  end
 end


### PR DESCRIPTION
This change is also needed to open a GPIO more than once as an output.
Sysfs initializes outputs to 0 when setting the GPIO's direction. This
changes the direction logic so that it checks the direction before
setting it if the output should retain its value.