### PR TITLE
Lint markdown files on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,13 @@ install_system_deps: &install_system_deps
       apt update
       apt install -y unzip
 
+install_mdl: &install_mdl
+  run:
+    name: Install Markdown Lint
+    command: |
+      apt install -y ruby
+      gem install mdl
+
 defaults: &defaults
   working_directory: ~/repo
 
@@ -36,6 +43,7 @@ jobs:
     steps:
       - checkout
       - <<: *install_system_deps
+      - <<: *install_mdl
       - <<: *install_elixir
       - <<: *install_hex_rebar
       - restore_cache:
@@ -47,6 +55,7 @@ jobs:
       - run: mix docs
       - run: mix hex.build
       - run: mix test
+      - run: mdl --style .circleci/md-style.rb *.md
       - run: mix dialyzer --halt-exit-status
       - save_cache:
           key: v1-mix-cache-{{ checksum "mix.lock" }}

--- a/.circleci/md-style.rb
+++ b/.circleci/md-style.rb
@@ -1,0 +1,3 @@
+all
+exclude_rule 'MD026'
+rule 'MD029', :style => 'ordered'

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ iex> Circuits.GPIO.close(gpio)
 :ok
 ```
 
-_Note that the call to `Circuits.GPIO.close/1` is not necessary, as the garbage 
+_Note that the call to `Circuits.GPIO.close/1` is not necessary, as the garbage
 collector will free up any unreferenced GPIOs. It can be used to explicitly
 de-allocate connections you know you will not need anymore._
 
@@ -229,7 +229,7 @@ The following advice from Elixir/ALE may also be useful: You'll need to fake out
 the hardware. Code to do this depends on what your hardware actually does, but
 here's one example:
 
-* http://www.cultivatehq.com/posts/compiling-and-testing-elixir-nerves-on-your-host-machine/
+* [Compiling and testing Elixir Nerves on your host machine](https://cultivatehq.com/posts/compiling-and-testing-elixir-nerves-on-your-host-machine/)
 
 ### How do I call Circuits.GPIO from Erlang?
 


### PR DESCRIPTION
While this isn't an issue with circuits_gpio or any of the circuits projects, Markdown issues (bad code fences so code highlighting doesn't work, duplicate headers so linking to sections breaks) happen in other projects I'm involved with and this seemed like a good place to try this out.