### PR TITLE
gpio->circuits_gpio message label

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ iex> Circuits.GPIO.set_interrupts(gpio, :both)
 :ok
 
 iex> flush
-{:gpio, 17, 1233456, 1}
-{:gpio, 17, 1234567, 0}
+{:circuits_gpio, 17, 1233456, 1}
+{:circuits_gpio, 17, 1234567, 0}
 :ok
 ```
 

--- a/lib/gpio.ex
+++ b/lib/gpio.ex
@@ -119,7 +119,7 @@ defmodule Circuits.GPIO do
   Notifications look like:
 
   ```
-  {:gpio, pin_number, timestamp, value}
+  {:circuits_gpio, pin_number, timestamp, value}
   ```
 
   Where `pin_number` is the pin that changed values, `timestamp` is roughly when

--- a/src/hal_stub.c
+++ b/src/hal_stub.c
@@ -115,7 +115,7 @@ static void maybe_send_notification(ErlNifEnv *env, struct stub_priv *hal_priv, 
 
     if (sendit) {
         ErlNifTime now = enif_monotonic_time(ERL_NIF_NSEC);
-        send_gpio_message(env, enif_make_atom(env, "gpio"), pin_number, &hal_priv->pid[pin_number], now, value);
+        send_gpio_message(env, enif_make_atom(env, "circuits_gpio"), pin_number, &hal_priv->pid[pin_number], now, value);
     }
 }
 

--- a/src/hal_sysfs_interrupts.c
+++ b/src/hal_sysfs_interrupts.c
@@ -145,7 +145,7 @@ void *gpio_poller_thread(void *arg)
     debug("gpio_poller_thread started");
 
     ErlNifEnv *env = enif_alloc_env();
-    ERL_NIF_TERM atom_gpio = enif_make_atom(env, "gpio");
+    ERL_NIF_TERM atom_gpio = enif_make_atom(env, "circuits_gpio");
 
     init_listeners(monitor_info);
     for (;;) {

--- a/test/circuits_gpio_test.exs
+++ b/test/circuits_gpio_test.exs
@@ -121,7 +121,7 @@ defmodule Circuits.GPIOTest do
     {:ok, gpio1} = GPIO.open(1, :input)
 
     :ok = GPIO.set_interrupts(gpio1, :both)
-    assert_receive {:gpio, 1, _timestamp, 0}
+    assert_receive {:circuits_gpio, 1, _timestamp, 0}
 
     GPIO.close(gpio0)
     GPIO.close(gpio1)
@@ -132,13 +132,13 @@ defmodule Circuits.GPIOTest do
     {:ok, gpio1} = GPIO.open(1, :input)
 
     :ok = GPIO.set_interrupts(gpio1, :both)
-    assert_receive {:gpio, 1, _timestamp, 0}
+    assert_receive {:circuits_gpio, 1, _timestamp, 0}
 
     :ok = GPIO.write(gpio0, 1)
-    assert_receive {:gpio, 1, _timestamp, 1}
+    assert_receive {:circuits_gpio, 1, _timestamp, 1}
 
     :ok = GPIO.write(gpio0, 0)
-    assert_receive {:gpio, 1, _timestamp, 0}
+    assert_receive {:circuits_gpio, 1, _timestamp, 0}
 
     GPIO.close(gpio0)
     GPIO.close(gpio1)
@@ -149,13 +149,13 @@ defmodule Circuits.GPIOTest do
     {:ok, gpio1} = GPIO.open(1, :input)
 
     :ok = GPIO.set_interrupts(gpio1, :falling)
-    assert_receive {:gpio, 1, _timestamp, 0}
+    assert_receive {:circuits_gpio, 1, _timestamp, 0}
 
     :ok = GPIO.write(gpio0, 1)
-    refute_receive {:gpio, 1, _timestamp, 1}
+    refute_receive {:circuits_gpio, 1, _timestamp, 1}
 
     :ok = GPIO.write(gpio0, 0)
-    assert_receive {:gpio, 1, _timestamp, 0}
+    assert_receive {:circuits_gpio, 1, _timestamp, 0}
 
     GPIO.close(gpio0)
     GPIO.close(gpio1)
@@ -166,13 +166,13 @@ defmodule Circuits.GPIOTest do
     {:ok, gpio1} = GPIO.open(1, :input)
 
     :ok = GPIO.set_interrupts(gpio1, :rising)
-    refute_receive {:gpio, 1, _timestamp, 0}
+    refute_receive {:circuits_gpio, 1, _timestamp, 0}
 
     :ok = GPIO.write(gpio0, 1)
-    assert_receive {:gpio, 1, _timestamp, 1}
+    assert_receive {:circuits_gpio, 1, _timestamp, 1}
 
     :ok = GPIO.write(gpio0, 0)
-    refute_receive {:gpio, 1, _timestamp, 0}
+    refute_receive {:circuits_gpio, 1, _timestamp, 0}
 
     GPIO.close(gpio0)
     GPIO.close(gpio1)
@@ -183,14 +183,14 @@ defmodule Circuits.GPIOTest do
     {:ok, gpio1} = GPIO.open(1, :input)
 
     :ok = GPIO.set_interrupts(gpio1, :both)
-    assert_receive {:gpio, 1, _timestamp, 0}
+    assert_receive {:circuits_gpio, 1, _timestamp, 0}
 
     :ok = GPIO.write(gpio0, 1)
-    assert_receive {:gpio, 1, _timestamp, 1}
+    assert_receive {:circuits_gpio, 1, _timestamp, 1}
 
     :ok = GPIO.set_interrupts(gpio1, :none)
     :ok = GPIO.write(gpio0, 0)
-    refute_receive {:gpio, 1, _timestamp, 0}
+    refute_receive {:circuits_gpio, 1, _timestamp, 0}
 
     GPIO.close(gpio0)
     GPIO.close(gpio1)
@@ -201,16 +201,16 @@ defmodule Circuits.GPIOTest do
     {:ok, gpio1} = GPIO.open(1, :input)
 
     :ok = GPIO.set_interrupts(gpio1, :both)
-    assert_receive {:gpio, 1, _timestamp, 0}
+    assert_receive {:circuits_gpio, 1, _timestamp, 0}
 
     :ok = GPIO.write(gpio0, 1)
-    assert_receive {:gpio, 1, _timestamp, 1}
+    assert_receive {:circuits_gpio, 1, _timestamp, 1}
 
     GPIO.close(gpio1)
     Process.sleep(10)
 
     :ok = GPIO.write(gpio0, 0)
-    refute_receive {:gpio, 1, _timestamp, 0}
+    refute_receive {:circuits_gpio, 1, _timestamp, 0}
 
     GPIO.close(gpio0)
   end


### PR DESCRIPTION
Closes #31 

In the issue, you said `circuits_uart` (that is circuit with an `s`), but wanted to change `gpio` to `circuit_gpio`. I assumed that you meant to add an `s` at the end of `circuit` as the org is `Elixir Circuits` and UART is `circuits_uart`, let me know if you meant without an `s`.

Still needs to be exercised on real hardware.