### PR TITLE
Pass build path to Makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,11 @@ defaults: &defaults
   working_directory: ~/repo
 
 jobs:
-  build_elixir_1_7_otp_21:
+  build_elixir_1_8_otp_21:
     docker:
-      - image: erlang:21.1
+      - image: erlang:21.2
         environment:
-          ELIXIR_VERSION: 1.7.4-otp-21
+          ELIXIR_VERSION: 1.8.1-otp-21
           LC_ALL: C.UTF-8
     <<: *defaults
     steps:
@@ -53,6 +53,23 @@ jobs:
           paths:
             - _build
             - deps
+
+  build_elixir_1_7_otp_21:
+    docker:
+      - image: erlang:21.1
+        environment:
+          ELIXIR_VERSION: 1.7.4-otp-21
+          LC_ALL: C.UTF-8
+          SUDO: true
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_system_deps
+      - <<: *install_elixir
+      - <<: *install_hex_rebar
+      - run: mix deps.get
+      - run: mix compile
+      - run: mix test
 
   build_elixir_1_6_otp_21:
     docker:
@@ -92,6 +109,7 @@ workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_8_otp_21
       - build_elixir_1_7_otp_21
       - build_elixir_1_6_otp_21
       - build_elixir_1_6_otp_20

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
       - run: mix deps.get
       - run: mix format --check-formatted
       - run: mix hex.build
+      - run: mix compile
       - run: mix test
       - run: mix docs
       - run: mix dialyzer --halt-exit-status
@@ -67,6 +68,7 @@ jobs:
       - <<: *install_elixir
       - <<: *install_hex_rebar
       - run: mix deps.get
+      - run: mix compile
       - run: mix test
 
   build_elixir_1_6_otp_20:
@@ -83,6 +85,7 @@ jobs:
       - <<: *install_elixir
       - <<: *install_hex_rebar
       - run: mix deps.get
+      - run: mix compile
       - run: mix test
 
 workflows:

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,12 @@
 # ERL_EI_LIBDIR path to libei.a (Required for crosscompile)
 # LDFLAGS	linker flags for linking all binaries
 # ERL_LDFLAGS	additional linker flags for projects referencing Erlang libraries
+# PREFIX the path to the installation direction (defaults to the current directory)
 
-NIF=priv/gpio_nif.so
+PREFIX ?= .
+NIF = $(PREFIX)/priv/gpio_nif.so
 
-TARGETS=$(NIF)
+TARGETS = $(NIF)
 
 NIF_LDFLAGS = $(LDFLAGS)
 TARGET_CFLAGS = $(shell src/detect_target.sh)
@@ -51,10 +53,10 @@ HEADERS =$(wildcard src/*.h)
 calling_from_make:
 	mix compile
 
-all: priv $(TARGETS)
+all: $(PREFIX)/priv $(TARGETS)
 
-priv:
-	mkdir -p priv
+$(PREFIX)/priv:
+	mkdir -p $@
 
 $(NIF): $(HEADERS) Makefile
 

--- a/mix.exs
+++ b/mix.exs
@@ -16,6 +16,7 @@ defmodule Circuits.GPIO.MixProject do
       docs: [extras: ["README.md"], main: "readme"],
       aliases: [docs: ["docs", &copy_images/1], format: [&format_c/1, "format"]],
       start_permanent: Mix.env() == :prod,
+      build_embedded: true,
       deps: deps()
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Circuits.GPIO.MixProject do
       compilers: [:elixir_make | Mix.compilers()],
       make_targets: ["all"],
       make_clean: ["clean"],
-      make_env: make_env(),
+      make_env: &make_env/0,
       docs: [extras: ["README.md"], main: "readme"],
       aliases: [docs: ["docs", &copy_images/1], format: [&format_c/1, "format"]],
       start_permanent: Mix.env() == :prod,
@@ -21,7 +21,10 @@ defmodule Circuits.GPIO.MixProject do
   end
 
   defp make_env() do
-    %{"MIX_ENV" => to_string(Mix.env())}
+    %{
+      "MIX_ENV" => to_string(Mix.env()),
+      "PREFIX" => Path.join(Mix.Project.compile_path(), "..")
+    }
     |> Map.merge(ei_env())
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -21,9 +21,15 @@ defmodule Circuits.GPIO.MixProject do
   end
 
   defp make_env() do
+    base =
+      Mix.Project.compile_path()
+      |> Path.join("..")
+      |> Path.expand()
+
     %{
       "MIX_ENV" => to_string(Mix.env()),
-      "PREFIX" => Path.join(Mix.Project.compile_path(), "..")
+      "PREFIX" => Path.join(base, "priv"),
+      "BUILD" => Path.join(base, "obj")
     }
     |> Map.merge(ei_env())
   end

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.4", "71b42f5ee1b7628f3e3a6565f4617dfb02d127a0499ab3e72750455e986df001", [:mix], [{:erlex, "~> 0.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
-  "erlex": {:hex, :erlex, "0.1.6", "c01c889363168d3fdd23f4211647d8a34c0f9a21ec726762312e08e083f3d47e", [:mix], [], "hexpm"},
+  "erlex": {:hex, :erlex, "0.2.0", "80349ebd58553dbd63489937380bfa7d906be3266b91bbd9d2bd6b71f1e8c07d", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
When switching between mix targets, the C build products need to be
stored in separate build directories or the wrong ones will be used.
This passes the build directory to the Makefile in the $PREFIX
environment variable. Using $PREFIX is a C convention for specifying the
base install directory.

If this project is being included as a dependency, the top level
`mix.exs` must have `build_embedded: true`. If `build_embedded` is
`false`, then the `priv` directory will be a symlink to a common
directory and this won't work.