### PR TITLE
Simplifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,7 @@
 #
 # Variables to override:
 #
-# BUILD         where to store intermediate files (defaults to src directory)
-# PREFIX        path to the installation direction (defaults to ./priv)
+# MIX_COMPILE_PATH path to the build's ebin directory
 #
 # CC            C compiler
 # CROSSCOMPILE	crosscompiler prefix, if any
@@ -19,8 +18,8 @@
 # LDFLAGS	linker flags for linking all binaries
 # ERL_LDFLAGS	additional linker flags for projects referencing Erlang libraries
 
-PREFIX ?= priv
-BUILD ?= src
+PREFIX = $(MIX_COMPILE_PATH)/../priv
+BUILD = $(MIX_COMPILE_PATH)/../obj
 
 NIF = $(PREFIX)/gpio_nif.so
 

--- a/PORTING.md
+++ b/PORTING.md
@@ -45,7 +45,7 @@ The remain modifications should mostly be mechanical:
 3. Change calls to `ElixirALE.GPIO.set_int/2` to
    `Circuits.GPIO.set_interrupts/3`.
 4. Change the pattern match for the GPIO interrupt events to match 4 tuples.
-   They have the form `{:gpio, <pin_number>, <timestamp>, <value>}`
+   They have the form `{:circuits_gpio, <pin_number>, <timestamp>, <value>}`
 5. Review calls to `write/2` to ensure that they pass `0` or `1`. `ElixirALE`
    allowed users to pass `true` and `false`. That won't work. Running Dialyzer
    should catch this change as well.

--- a/mix.exs
+++ b/mix.exs
@@ -12,40 +12,12 @@ defmodule Circuits.GPIO.MixProject do
       compilers: [:elixir_make | Mix.compilers()],
       make_targets: ["all"],
       make_clean: ["clean"],
-      make_env: &make_env/0,
       docs: [extras: ["README.md", "PORTING.md"], main: "readme"],
       aliases: [docs: ["docs", &copy_images/1], format: [&format_c/1, "format"]],
       start_permanent: Mix.env() == :prod,
       build_embedded: true,
       deps: deps()
     ]
-  end
-
-  defp make_env() do
-    base =
-      Mix.Project.compile_path()
-      |> Path.join("..")
-      |> Path.expand()
-
-    %{
-      "MIX_ENV" => to_string(Mix.env()),
-      "PREFIX" => Path.join(base, "priv"),
-      "BUILD" => Path.join(base, "obj")
-    }
-    |> Map.merge(ei_env())
-  end
-
-  defp ei_env() do
-    case System.get_env("ERL_EI_INCLUDE_DIR") do
-      nil ->
-        %{
-          "ERL_EI_INCLUDE_DIR" => "#{:code.root_dir()}/usr/include",
-          "ERL_EI_LIBDIR" => "#{:code.root_dir()}/usr/lib"
-        }
-
-      _ ->
-        %{}
-    end
   end
 
   def application, do: []
@@ -73,7 +45,7 @@ defmodule Circuits.GPIO.MixProject do
 
   defp deps do
     [
-      {:elixir_make, "~> 0.4", runtime: false},
+      {:elixir_make, "~> 0.5", runtime: false},
       {:ex_doc, "~> 0.11", only: :dev, runtime: false},
       {:dialyxir, "1.0.0-rc.4", only: :dev, runtime: false}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.4", "71b42f5ee1b7628f3e3a6565f4617dfb02d127a0499ab3e72750455e986df001", [:mix], [{:erlex, "~> 0.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
-  "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
-  "erlex": {:hex, :erlex, "0.2.0", "80349ebd58553dbd63489937380bfa7d906be3266b91bbd9d2bd6b71f1e8c07d", [:mix], [], "hexpm"},
+  "elixir_make": {:hex, :elixir_make, "0.5.1", "cee27c69bddcd6e333a24f2313786d1c9a970c49fcf700ecf1f7246f3a210f39", [:mix], [], "hexpm"},
+  "erlex": {:hex, :erlex, "0.2.1", "cee02918660807cbba9a7229cae9b42d1c6143b768c781fa6cee1eaf03ad860b", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
`elixir_make` was just updated to include several of the variables that we manually defined. This change bumps the `elixir_make` and takes advantage of those new variables to simplify the `mix.exs`.