### PR TITLE
Clarify what the interrupt timestamp value is

### DIFF
--- a/lib/gpio.ex
+++ b/lib/gpio.ex
@@ -123,7 +123,8 @@ defmodule Circuits.GPIO do
   ```
 
   Where `pin_number` is the pin that changed values, `timestamp` is roughly when
-  the transition occurred in nanoseconds, and `value` is the new value.
+  the transition occurred in nanoseconds since host system boot time,
+  and `value` is the new value.
   """
   @spec set_interrupts(reference(), trigger(), list()) :: :ok | {:error, atom()}
   def set_interrupts(gpio, trigger, opts \\ []) do


### PR DESCRIPTION
Tiny documentation update for timestamps. Normally one would expect an integer timestamp to be relative to the UNIX epoch, but these are nanoseconds since the host system boot (a.la `/proc/uptime`)