### PR TITLE
Avoid sysfs symlink race condition

### DIFF
--- a/src/hal_sysfs.c
+++ b/src/hal_sysfs.c
@@ -174,7 +174,8 @@ int hal_open_gpio(struct gpio_pin *pin,
             return -1;
         }
 
-        pin->fd = open(value_path, O_RDWR);
+        // wait up to 1000ms for the gpio symlink to be created
+        pin->fd = retry_open(value_path, O_RDWR, 1000);
         if (pin->fd < 0) {
             strcpy(error_str, "access_denied");
             return -1;


### PR DESCRIPTION
As discussed in #45, this is a race condition where it may take a few ticks for the symlink to be created. Wait up to 1 second, although on a Raspberry Pi for example it is usually created in under 20ms