### PR TITLE
Fix bcm_host.h detection and error printout on Raspbian

### DIFF
--- a/src/detect_target.sh
+++ b/src/detect_target.sh
@@ -13,8 +13,11 @@ fi
 #
 
 # Is the bcmhost.h header file available?
+if [ -e /opt/vc/include/bcm_host.h ]; then
+    EXTRA_CFLAGS=-I/opt/vc/include
+fi
 
-$CC $CFLAGS -o /dev/null -xc - 2>/dev/null <<EOF
+$CC $CFLAGS $EXTRA_CFLAGS -o /dev/null -xc - 2>/dev/null <<EOF
 #include <bcm_host.h>
 
 int main(int argc,char *argv[]) {
@@ -22,6 +25,6 @@ int main(int argc,char *argv[]) {
 }
 EOF
 if [ "$?" = "0" ]; then
-    printf -- "-DTARGET_RPI -lbcm_host"
+    printf -- "-DTARGET_RPI $EXTRA_CFLAGS -lbcm_host"
 fi
 

--- a/src/hal_sysfs.c
+++ b/src/hal_sysfs.c
@@ -42,9 +42,9 @@ static int retry_open(const char *pathname, int flags, int retries)
         if (fd >= 0)
             return fd;
 
-        error("Error opening %s", pathname);
-        usleep(1000);
         retries--;
+        debug("Error opening %s. Retrying %d times", pathname, retries);
+        usleep(1000);
     } while (retries > 0);
 
     return -1;


### PR DESCRIPTION
The bcm_host.h detection fix makes the pullup/pulldown feature work on Raspbian without any extra flags. This also silences the prints when the GPIO files can't be opened, since the errors are expected on Raspbian and there's no need for the user to worry about them.