### PR TITLE
Add note to stub in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ iex> Circuits.GPIO.read(gpio1)
 The stub HAL is fairly limited, but it does support interrupts.
 
 In case `Circuits.GPIO` is used as a dependency the stub will not be present.
-Currently the stub is only available when the `:env` dependency option is set 
+Currently the stub is only available when the `:env` dependency option is set
 to `:test`.
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ iex> Circuits.GPIO.read(gpio1)
 
 The stub HAL is fairly limited, but it does support interrupts.
 
+In case `Circuits.GPIO` is used as a dependency the stub will not be present.
+Currently the stub is only available when the `:env` dependency option is set 
+to `:test`.
+
 ## FAQ
 
 ### How does Circuits.GPIO compare to Elixir/ALE?


### PR DESCRIPTION
#57 

This could be a good help for everyone who tries to use the stub mode in unit tests out side the Circuits.GPIO project.