### PR TITLE
Enable "stub" hardware abstraction layer compilation on platforms without GPIO support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ TARGET_CFLAGS = $(shell src/detect_target.sh)
 CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic
 CFLAGS += $(TARGET_CFLAGS)
 
+$(info "**** MIX_ENV set to [$(MIX_ENV)] ****")
+$(info "**** CIRCUIT_MIX_ENV set to [$(CIRCUIT_MIX_ENV)] ****")
+
 # Check that we're on a supported build platform
 ifeq ($(CROSSCOMPILE),)
     # Not crosscompiling.
@@ -36,7 +39,7 @@ ifeq ($(CROSSCOMPILE),)
 	HAL_SRC = src/hal_stub.c
         LDFLAGS += -undefined dynamic_lookup -dynamiclib
     else
-        ifeq ($(MIX_ENV),test)
+        ifneq ($(filter $(CIRCUIT_MIX_ENV) $(MIX_ENV),test),)
             $(warning Compiling stub NIF to support 'mix test')
             HAL_SRC = src/hal_stub.c
         endif


### PR DESCRIPTION
Hi,
I'm doing some tests on the 'Orange Pi PC' device.
On the device my tests work, but on my 'development pc' I have some problems performing tests without GPIO support.
I'm not found any solution to compiling stub NIF for 'mix test', even setting MIX_ENV variable to 'test' during compilation is forced to 'prod' so test involving gpio fails.
My solution is to add another variable check into makefile (`CIRCUIT_MIX_ENV`) , this made compilation compatible with previous version but allows the possibility to enable the abstraction layer compilation.
I propose this patch to correct the problem.

Thanks in advance for your work
Enrico
