### PR TITLE
Implement rpi4 pullmodes

### DIFF
--- a/src/hal_rpi.c
+++ b/src/hal_rpi.c
@@ -26,6 +26,17 @@
 #define ENABLE_PULLDOWN     1
 #define ENABLE_PULLUP       2
 
+/* RPi4 (BCM2711) has a different mechanism for pin pull-up/down/enable  */
+#define GPPUPPDN0           57        /* Pin pull-up/down for pins 15:0  */
+#define GPPUPPDN1           58        /* Pin pull-up/down for pins 31:16 */
+#define GPPUPPDN2           59        /* Pin pull-up/down for pins 47:32 */
+#define GPPUPPDN3           60        /* Pin pull-up/down for pins 57:48 */
+
+// RPi4 PULL-UP and PUL-DOWN values are reversed from other RPi models.
+#define RPI4_ENABLE_PULLDOWN     2
+#define RPI4_ENABLE_PULLUP       1
+
+
 ERL_NIF_TERM rpi_info(ErlNifEnv *env, struct sysfs_priv *priv, ERL_NIF_TERM info)
 {
     enif_make_map_put(env, info, enif_make_atom(env, "rpi_using_gpiomem"), priv->gpio_mem ? enif_make_atom(env, "true") : enif_make_atom(env, "false"), &info);
@@ -82,36 +93,63 @@ static uint32_t pull_to_rpi(enum pull_mode pull)
     }
 }
 
+static uint32_t rpi4_pull_to_rpi(enum pull_mode pull)
+{
+    switch (pull) {
+    default:
+    case PULL_NONE:
+        return 0;
+    case PULL_DOWN:
+        return RPI4_ENABLE_PULLDOWN;
+    case PULL_UP:
+        return RPI4_ENABLE_PULLUP;
+    }
+}
+
 int rpi_apply_pull_mode(struct gpio_pin *pin)
 {
     struct sysfs_priv *priv = pin->hal_priv;
     if (priv->gpio_mem == NULL && rpi_load(priv) != 0)
         return -1;
 
-    uint32_t  clk_bit_to_set = 1 << (pin->pin_number % 32);
-    uint32_t *gpio_pud_clk = priv->gpio_mem + GPPUDCLK0_OFFSET + (pin->pin_number / 32);
-    uint32_t *gpio_pud = priv->gpio_mem + GPPUD_OFFSET;
+    int32_t is_rpi4 = (*(priv->gpio_mem + GPPUPPDN3) != 0x6770696f);
 
-    // Steps to connect or disconnect pull up/down resistors on a gpio pin:
+    if (is_rpi4) {
+        int32_t pullreg = GPPUPPDN0 + (pin->pin_number >> 4);
+        int32_t pullshift = (pin->pin_number & 0xf) << 1;
 
-    // 1. Write to GPPUD to set the required control signal
-    *gpio_pud = (*gpio_pud & ~3) | pull_to_rpi(pin->config.pull);
+        uint32_t pull = rpi4_pull_to_rpi(pin->config.pull);
 
-    // 2. Wait 150 cycles  this provides the required set-up time for the control signal
-    usleep(1);
+        uint32_t pullbits = *(priv->gpio_mem + pullreg);
+        pullbits &= ~(3 << pullshift);
+        pullbits |= (pull << pullshift);
+        *(priv->gpio_mem + pullreg) = pullbits;
+    }
+    else { // RPi 3, 2, 1, Zero, etc
+        uint32_t  clk_bit_to_set = 1 << (pin->pin_number % 32);
+        uint32_t *gpio_pud_clk = priv->gpio_mem + GPPUDCLK0_OFFSET + (pin->pin_number / 32);
+        uint32_t *gpio_pud = priv->gpio_mem + GPPUD_OFFSET;
 
-    // 3. Write to GPPUDCLK0/1 to clock the control signal into the GPIO pads you wish to modify
-    *gpio_pud_clk = clk_bit_to_set;
+        // Steps to connect or disconnect pull up/down resistors on a gpio pin:
 
-    // 4. Wait 150 cycles  this provides the required hold time for the control signal
-    usleep(1);
+        // 1. Write to GPPUD to set the required control signal
+        *gpio_pud = (*gpio_pud & ~3) | pull_to_rpi(pin->config.pull);
 
-    // 5. Write to GPPUD to remove the control signal
-    *gpio_pud &= ~3;
+        // 2. Wait 150 cycles  this provides the required set-up time for the control signal
+        usleep(1);
 
-    // 6. Write to GPPUDCLK0/1 to remove the clock
-    *gpio_pud_clk = 0;
+        // 3. Write to GPPUDCLK0/1 to clock the control signal into the GPIO pads you wish to modify
+        *gpio_pud_clk = clk_bit_to_set;
 
+        // 4. Wait 150 cycles  this provides the required hold time for the control signal
+        usleep(1);
+
+        // 5. Write to GPPUD to remove the control signal
+        *gpio_pud &= ~3;
+
+        // 6. Write to GPPUDCLK0/1 to remove the clock
+        *gpio_pud_clk = 0;
+    }
     return 0;
 }
 #endif // TARGET_RPI

--- a/test/circuits_gpio_test.exs
+++ b/test/circuits_gpio_test.exs
@@ -69,6 +69,9 @@ defmodule Circuits.GPIOTest do
       send(me, {:done, length(x)})
     end)
 
+    # Wait a tehth of a second to allow spawned task to complete
+    Process.sleep(100)
+
     assert_receive {:done, ^count}
 
     # Wait a fraction of a second to allow GC to run since there's


### PR DESCRIPTION
Tested this change on rpi4, rpi3, and rpi2. 
Pull up/down resistor switch, works for rpi4 now, and older rpi models are not affected. 
Also fixed a test that was failing the Circle CI build.
Let me know if you have any suggested changes or other tests I should perform.