### PR TITLE
Fix glitch suppression

### DIFF
--- a/src/hal_sysfs_interrupts.c
+++ b/src/hal_sysfs_interrupts.c
@@ -244,6 +244,7 @@ int update_polling_thread(struct gpio_pin *pin)
     message.pid = pin->config.pid;
     message.last_value = -1;
     message.trigger = pin->config.trigger;
+    message.suppress_glitches = pin->config.suppress_glitches;
     if (write(priv->pipe_fds[1], &message, sizeof(message)) != sizeof(message)) {
         error("Error writing polling thread!");
         return -1;


### PR DESCRIPTION
Short glitches can be reported or suppressed. Unfortunately, the
uninitialized suppress_glitches field was left uninitialized, so its
setting was random. This fixes that setting.