### PR TITLE
Don't clear interrupts if not listening

### DIFF
--- a/src/hal_sysfs.c
+++ b/src/hal_sysfs.c
@@ -189,7 +189,10 @@ int hal_open_gpio(struct gpio_pin *pin,
         strcpy(error_str, "error_setting_pull_mode");
         goto error;
     }
-    if (hal_apply_interrupts(pin, env) < 0) {
+    // Only call hal_apply_interrupts if there's a trigger. While sysfs limits
+    // users to one "interrupt" handler, it's still nice to be able to check a
+    // a GPIO's state.
+    if (pin->config.trigger != TRIGGER_NONE && hal_apply_interrupts(pin, env) < 0) {
         strcpy(error_str, "error_setting_interrupts");
         goto error;
     }


### PR DESCRIPTION
This lets users open GPIOs that their program is using to look at their
value without affecting the interrupt status.

The previous behavior was to set the interrupt edge state and clear out
the interrupt listener if not listening. That would cause programs to
stop seeing GPIOs change when you'd look at the GPIO. Sysfs is limited
and really only supports one GPIO user at a time, but it's reasonable to
expect that you can read a GPIO without messing up your program.

This is a safe change since there are two cases:

1. The user wants to listen for interrupts. In this case, the operation
is unchanged.

2. The user doesn't want to listen for interrupts. Now the `edge` file
isn't set and the interrupt polling thread isn't configured. This is ok,
since if `edge` is set to anything besides none, no one will no anyway.
Also, the interrupt polling thread won't be listening if there are no
listeners since either 1. no listeners were ever registered or 2. any
previously listening calls that were closed will have cleaned it up.