### PR TITLE
Fixed compatibility issue in detect_target.sh

### DIFF
--- a/src/detect_target.sh
+++ b/src/detect_target.sh
@@ -4,7 +4,7 @@
 # Detect the platform and output -D flags for use in compilion
 #
 
-if [ -z $CC ]; then
+if [ -z "$CC" ]; then
   CC=cc
 fi
 


### PR DESCRIPTION
Depending on bash flavour/version, quotes are needed in the -z check.
Quotes are more widely compatible and are required for yocto builds.