### PR TITLE
Terminate interrupt thread on NIF unload

### DIFF
--- a/src/hal_sysfs_interrupts.c
+++ b/src/hal_sysfs_interrupts.c
@@ -181,7 +181,12 @@ void *gpio_poller_thread(void *arg)
         // enif_monotonic_time only works in scheduler threads
         //ErlNifTime timestamp = enif_monotonic_time(ERL_NIF_NSEC);
 
-        if (fdset[count - 1].revents & (POLLIN | POLLHUP)) {
+        short revents = fdset[count - 1].revents;
+        if (revents & (POLLERR | POLLNVAL)) {
+            // Socket closed so quit thread. This happens on NIF unload.
+            break;
+        }
+        if (revents & (POLLIN | POLLHUP)) {
             struct gpio_monitor_info message;
             ssize_t amount_read = read(*pipefd, &message, sizeof(message));
             if (amount_read != sizeof(message)) {


### PR DESCRIPTION
This fixes an issue where the NIF could not be unloaded due to the
interrupt monitoring thread never stopping. This would manifest itself
in `:init.stop` taking a long time or it breaking `runtime.exs` due to a
change that requires the VM to be restarted.

Fixes #78 
