### PR TITLE
Remove Erlang wrapper

### DIFF
--- a/lib/gpio.ex
+++ b/lib/gpio.ex
@@ -176,20 +176,4 @@ defmodule Circuits.GPIO do
   """
   @spec info() :: map()
   defdelegate info(), to: Nif
-
-  defmodule :circuits_gpio do
-    @moduledoc """
-    Erlang interface to Circuits.GPIO
-
-    Example Erlang code:  `circuits_gpio:open(5, output)`
-    """
-    defdelegate open(pin_number, pin_direction), to: Circuits.GPIO
-    defdelegate read(gpio), to: Circuits.GPIO
-    defdelegate write(gpio, value), to: Circuits.GPIO
-    defdelegate set_interrupts(gpio, trigger), to: Circuits.GPIO
-    defdelegate set_interrupts(gpio, trigger, opts), to: Circuits.GPIO
-    defdelegate set_direction(gpio, pin_direction), to: Circuits.GPIO
-    defdelegate set_pull_mode(gpio, pull_mode), to: Circuits.GPIO
-    defdelegate pin(gpio), to: Circuits.GPIO
-  end
 end


### PR DESCRIPTION
A long time ago we made an Erlang wrapper so that the library was friendlier to
use from Erlang code. Based on support requests I don't think anyone uses it.
This PR removes it so that we don't have to maintain it going forward. I can't
think of any other Elixir library that maintains an Erlang wrapper and my
experience with many Erlang programmers is that they'd prefer to reimplement an
Elixir library (especially a small one like this) than pull in the Elixir
runtime.

If this PR doesn't get any push back, my plan to remove the Erlang wrappers from
the other Circuits libraries as well.
