### PR TITLE
modify hal_apply_direction/1 for pins not activated "in" by simply exporting

### DIFF
--- a/src/hal_sysfs.c
+++ b/src/hal_sysfs.c
@@ -276,10 +276,7 @@ int hal_apply_direction(struct gpio_pin *pin)
 
     if (pin->config.is_output == 0) {
         // Input
-        if (!current_is_output)
-            return 0;
-        else
-            return sysfs_write_file(direction_path, "in", 0);
+        return sysfs_write_file(direction_path, "in", 0);
     } else {
         // Output
         if (pin->config.initial_value < 0) {


### PR DESCRIPTION
There are pins that have "in" direction after export, but not be activated.
These pins will not become active unless they are overwritten again.
Therefore, modified it to write always.

WHY: not apply this modifying for "out"

Because overwriting "out" has a side effect of changing the GPIO value.