### PR TITLE
Move common NIF atoms to globals per best practice

### DIFF
--- a/c_src/gpio_nif.c
+++ b/c_src/gpio_nif.c
@@ -13,6 +13,9 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+ERL_NIF_TERM atom_ok;
+ERL_NIF_TERM atom_error;
+
 static void release_gpio_pin(struct gpio_priv *priv, struct gpio_pin *pin)
 {
     if (pin->fd >= 0) {
@@ -91,6 +94,9 @@ static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM info)
 #endif
     debug("load");
 
+    atom_ok = enif_make_atom(env, "ok");
+    atom_error = enif_make_atom(env, "error");
+
     size_t extra_size = hal_priv_size();
     struct gpio_priv *priv = enif_alloc(sizeof(struct gpio_priv) + extra_size);
     if (!priv) {
@@ -99,8 +105,6 @@ static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM info)
     }
 
     priv->pins_open = 0;
-    priv->atom_ok = enif_make_atom(env, "ok");
-
     priv->gpio_pin_rt = enif_open_resource_type_x(env, "gpio_pin", &gpio_pin_init, ERL_NIF_RT_CREATE, NULL);
 
     if (hal_load(&priv->hal_priv) < 0) {
@@ -155,7 +159,7 @@ static ERL_NIF_TERM write_gpio(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv
     if (hal_write_gpio(pin, value, env) < 0)
         return enif_raise_exception(env, enif_make_atom(env, strerror(errno)));
 
-    return priv->atom_ok;
+    return atom_ok;
 }
 
 static int get_trigger(ErlNifEnv *env, ERL_NIF_TERM term, enum trigger_mode *mode)
@@ -236,7 +240,7 @@ static ERL_NIF_TERM set_interrupts(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
         return make_error_tuple(env, "hal_apply_interrupts");
     }
 
-    return priv->atom_ok;
+    return atom_ok;
 }
 
 static ERL_NIF_TERM set_direction(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
@@ -257,7 +261,7 @@ static ERL_NIF_TERM set_direction(ErlNifEnv *env, int argc, const ERL_NIF_TERM a
         return make_error_tuple(env, "write_pin_direction");
     }
 
-    return priv->atom_ok;
+    return atom_ok;
 }
 
 static ERL_NIF_TERM set_pull_mode(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
@@ -278,7 +282,7 @@ static ERL_NIF_TERM set_pull_mode(ErlNifEnv *env, int argc, const ERL_NIF_TERM a
         return make_error_tuple(env, "write_pull_mode");
     }
 
-    return priv->atom_ok;
+    return atom_ok;
 }
 
 static ERL_NIF_TERM pin_gpio(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
@@ -342,7 +346,7 @@ static ERL_NIF_TERM close_gpio(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv
 
     release_gpio_pin(priv, pin);
 
-    return priv->atom_ok;
+    return atom_ok;
 }
 static ERL_NIF_TERM gpio_info(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {

--- a/c_src/gpio_nif.h
+++ b/c_src/gpio_nif.h
@@ -44,8 +44,6 @@ enum pull_mode {
 };
 
 struct gpio_priv {
-    ERL_NIF_TERM atom_ok;
-
     ErlNifResourceType *gpio_pin_rt;
 
     int pins_open;
@@ -68,6 +66,10 @@ struct gpio_pin {
     void *hal_priv;
     struct gpio_config config;
 };
+
+// Atoms
+extern ERL_NIF_TERM atom_ok;
+extern ERL_NIF_TERM atom_error;
 
 // HAL
 

--- a/c_src/nif_utils.c
+++ b/c_src/nif_utils.c
@@ -8,17 +8,14 @@
 
 ERL_NIF_TERM make_ok_tuple(ErlNifEnv *env, ERL_NIF_TERM value)
 {
-    struct gpio_priv *priv = enif_priv_data(env);
-
-    return enif_make_tuple2(env, priv->atom_ok, value);
+    return enif_make_tuple2(env, atom_ok, value);
 }
 
 ERL_NIF_TERM make_error_tuple(ErlNifEnv *env, const char *reason)
 {
-    ERL_NIF_TERM error_atom = enif_make_atom(env, "error");
     ERL_NIF_TERM reason_atom = enif_make_atom(env, reason);
 
-    return enif_make_tuple2(env, error_atom, reason_atom);
+    return enif_make_tuple2(env, atom_error, reason_atom);
 }
 
 int enif_get_boolean(ErlNifEnv *env, ERL_NIF_TERM term, bool *v)


### PR DESCRIPTION
See https://erlangforums.com/t/atom-hashing-performance/2369/5.
