### PR TITLE
Defer loading the NIF until opening a GPIO

### DIFF
--- a/c_src/hal_stub.c
+++ b/c_src/hal_stub.c
@@ -26,7 +26,7 @@ ERL_NIF_TERM hal_info(ErlNifEnv *env, void *hal_priv, ERL_NIF_TERM info)
     return info;
 }
 
-size_t hal_priv_size()
+size_t hal_priv_size(void)
 {
     return sizeof(struct stub_priv);
 }

--- a/lib/gpio.ex
+++ b/lib/gpio.ex
@@ -50,7 +50,7 @@ defmodule Circuits.GPIO do
      input pin. `:not_set` is the default.
   """
   @spec open(pin_number(), pin_direction(), [open_option()]) ::
-          {:ok, reference()} | {:error, atom()}
+          {:ok, reference()} | {:error, any()}
   def open(pin_number, pin_direction, options \\ []) do
     check_open_options(options)
 

--- a/lib/gpio/gpio_nif.ex
+++ b/lib/gpio/gpio_nif.ex
@@ -3,19 +3,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Circuits.GPIO.Nif do
-  @on_load {:load_nif, 0}
-  @compile {:autoload, false}
-
   @moduledoc false
 
-  def load_nif() do
+  defp load_nif() do
     nif_binary = Application.app_dir(:circuits_gpio, "priv/gpio_nif")
 
     :erlang.load_nif(to_charlist(nif_binary), 0)
   end
 
-  def open(_pin_number, _pin_direction, _initial_value, _pull_mode) do
-    :erlang.nif_error(:nif_not_loaded)
+  def open(pin_number, pin_direction, initial_value, pull_mode) do
+    with :ok <- load_nif() do
+      apply(__MODULE__, :open, [pin_number, pin_direction, initial_value, pull_mode])
+    end
   end
 
   def close(_gpio) do
@@ -47,6 +46,7 @@ defmodule Circuits.GPIO.Nif do
   end
 
   def info() do
-    :erlang.nif_error(:nif_not_loaded)
+    :ok = load_nif()
+    apply(__MODULE__, :info, [])
   end
 end


### PR DESCRIPTION
This change moves the NIF load from the time at which the module is
loaded to the time when a GPIO actually needs to be used.

The primary motivation for doing this is to defer native code crashes
from happening at load time to the time of first use. Load time is
harder to debug and sometimes its not clear which NIF caused the crash.
