### PR TITLE
Cache GPIO enumeration results for faster opens

### DIFF
--- a/lib/gpio.ex
+++ b/lib/gpio.ex
@@ -103,8 +103,18 @@ defmodule Circuits.GPIO do
 
   @typedoc """
   Options for `open/3`
+
+  * `:initial_value` - the initial value of an output GPIO
+  * `:pull_mode` - the initial pull mode for an input GPIO
+  * `:force_enumeration` - Linux cdev-specific option to force a scan of
+    available GPIOs rather than using the cache. This is only for test purposes
+    since the GPIO cache should rescan as needed.
   """
-  @type open_options() :: [initial_value: value(), pull_mode: pull_mode()]
+  @type open_options() :: [
+          initial_value: value(),
+          pull_mode: pull_mode(),
+          force_enumeration: boolean()
+        ]
 
   @typedoc """
   Options for `set_interrupt/2`
@@ -289,7 +299,7 @@ defmodule Circuits.GPIO do
   @spec enumerate(backend() | nil) :: map()
   def enumerate(backend \\ nil)
   def enumerate(nil), do: enumerate(default_backend())
-  def enumerate({backend, _options}), do: backend.enumerate()
+  def enumerate({backend, options}), do: backend.enumerate(options)
 
   @doc """
   Guard version of gpio_spec?/1

--- a/lib/gpio/backend.ex
+++ b/lib/gpio/backend.ex
@@ -13,15 +13,16 @@ defmodule Circuits.GPIO.Backend do
   @doc """
   Return a list of GPIOs
 
-  See the `Line` struct for the information that is returned.
+  See the `Line` struct for the information that is returned. The `options` contain
+  backend-specific options to help with enumeration.
   """
-  @callback enumerate() :: [Line.t()]
+  @callback enumerate(options :: GPIO.open_options()) :: [Line.t()]
 
   @doc """
   Return information about a GPIO line
 
   See `t:gpio_spec/0` for the ways of referring to GPIOs. The `options` contain
-  and backend-specific options that would otherwise be passed to `open/3`.
+  backend-specific options to help enumerating GPIOs.
 
   If the GPIO is found, this function returns information about the GPIO.
   """

--- a/lib/gpio/nil_backend.ex
+++ b/lib/gpio/nil_backend.ex
@@ -11,7 +11,7 @@ defmodule Circuits.GPIO.NilBackend do
   alias Circuits.GPIO.Backend
 
   @impl Backend
-  def enumerate() do
+  def enumerate(_options) do
     []
   end
 


### PR DESCRIPTION
The GPIO enumeration rarely changes so this caches the results in
`:persistent_term`. To be safe, whenever a GPIO isn't found, the
enumeration is redone.

This optimises for the common cases where a set of GPIOs are opened on
boot and then only re-opened on GenServer restarts. It will also help in
the cases where the user does one-off GPIO sets or reads.

As part of this change, more tests were added to the `gpio_spec`
resolution code which fixed a few missed cases where `gpio_spec`'s that
should have resolved didn't.