### PR TITLE
Rename confusing use of gpio_spec to location

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,15 +205,33 @@ GPIOs](https://elixir.bootlin.com/linux/v6.6.6/source/Documentation/devicetree/b
 for more information on how to configure the fields of this struct for your own
 system.
 
+Here's an example:
+
 ```elixir
 iex> Circuits.GPIO.enumerate()
 [
-  %Circuits.GPIO.Line{gpio_spec: {"gpiochip0", 0}, label: "special-name-for-pin-0", controller: "gpiochip0"},
-  %Circuits.GPIO.Line{gpio_spec: {"gpiochip0", 1}, label: "special-name-for-pin-1", controller: "gpiochip0"},
-  %Circuits.GPIO.Line{gpio_spec: {"gpiochip1", 0}, label: "", controller: "gpiochip1"},
+  %Circuits.GPIO.Line{
+    location: {"gpiochip0", 0},
+    label: "ID_SDA",
+    controller: "pinctrl-bcm2835"
+  },
+  %Circuits.GPIO.Line{
+    location: {"gpiochip0", 1},
+    label: "ID_SCL",
+    controller: "pinctrl-bcm2835"
+  },
+  %Circuits.GPIO.Line{
+    location: {"gpiochip0", 2},
+    label: "SDA1",
+    controller: "pinctrl-bcm2835"
+  },
   ...
 ]
 ```
+
+The `:location` can always be passed as the first parameter to
+`Circuits.GPIO.open/3`. You may find the `:label` field more descriptive to
+use, though.
 
 ## Testing
 

--- a/c_src/gpio_nif.c
+++ b/c_src/gpio_nif.c
@@ -17,7 +17,7 @@ ERL_NIF_TERM atom_ok;
 ERL_NIF_TERM atom_error;
 ERL_NIF_TERM atom_name;
 ERL_NIF_TERM atom_label;
-ERL_NIF_TERM atom_gpio_spec;
+ERL_NIF_TERM atom_location;
 ERL_NIF_TERM atom_struct;
 ERL_NIF_TERM atom_circuits_gpio_line;
 ERL_NIF_TERM atom_controller;
@@ -113,7 +113,7 @@ static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM info)
     atom_error = enif_make_atom(env, "error");
     atom_name = enif_make_atom(env, "name");
     atom_label = enif_make_atom(env, "label");
-    atom_gpio_spec = enif_make_atom(env, "gpio_spec");
+    atom_location = enif_make_atom(env, "location");
     atom_controller = enif_make_atom(env, "controller");
     atom_struct = enif_make_atom(env, "__struct__");
     atom_circuits_gpio_line = enif_make_atom(env, "Elixir.Circuits.GPIO.Line");
@@ -214,7 +214,7 @@ static int get_direction(ErlNifEnv *env, ERL_NIF_TERM term, bool *is_output)
     return true;
 }
 
-static int get_resolved_pin_spec(ErlNifEnv *env, ERL_NIF_TERM term, char *gpiochip_path, int *offset)
+static int get_resolved_location(ErlNifEnv *env, ERL_NIF_TERM term, char *gpiochip_path, int *offset)
 {
     int arity;
     const ERL_NIF_TERM *tuple;
@@ -363,13 +363,13 @@ static ERL_NIF_TERM open_gpio(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     char gpiochip_path[MAX_GPIOCHIP_PATH_LEN];
 
     if (argc != 5 ||
-            !get_resolved_pin_spec(env, argv[1], gpiochip_path, &offset) ||
+            !get_resolved_location(env, argv[1], gpiochip_path, &offset) ||
             !get_direction(env, argv[2], &is_output) ||
             !get_value(env, argv[3], &initial_value) ||
             !get_pull_mode(env, argv[4], &pull))
         return enif_make_badarg(env);
 
-    debug("gpio_spec = .{.gpiochip = %s, .offset = %d}", gpiochip_path, offset);
+    debug("open {%s, %d}", gpiochip_path, offset);
 
     struct gpio_pin *pin = enif_alloc_resource(priv->gpio_pin_rt, sizeof(struct gpio_pin));
     pin->fd = -1;

--- a/c_src/gpio_nif.h
+++ b/c_src/gpio_nif.h
@@ -79,7 +79,7 @@ extern ERL_NIF_TERM atom_ok;
 extern ERL_NIF_TERM atom_error;
 extern ERL_NIF_TERM atom_name;
 extern ERL_NIF_TERM atom_label;
-extern ERL_NIF_TERM atom_gpio_spec;
+extern ERL_NIF_TERM atom_location;
 extern ERL_NIF_TERM atom_struct;
 extern ERL_NIF_TERM atom_circuits_gpio_line;
 extern ERL_NIF_TERM atom_controller;

--- a/c_src/hal_cdev_gpio.c
+++ b/c_src/hal_cdev_gpio.c
@@ -337,7 +337,7 @@ ERL_NIF_TERM hal_enumerate(ErlNifEnv *env, void *hal_priv)
                 enif_make_map_put(env, line_map, atom_struct, atom_circuits_gpio_line, &line_map);
                 enif_make_map_put(env, line_map, atom_controller, chip_label, &line_map);
                 enif_make_map_put(env, line_map, atom_label, line_label, &line_map);
-                enif_make_map_put(env, line_map, atom_gpio_spec, enif_make_tuple2(env, chip_name, line_offset), &line_map);
+                enif_make_map_put(env, line_map, atom_location, enif_make_tuple2(env, chip_name, line_offset), &line_map);
                 enif_make_map_put(env, line_map, atom_consumer, consumer, &line_map);
 
                 gpio_list = enif_make_list_cell(env, line_map, gpio_list);

--- a/c_src/hal_stub.c
+++ b/c_src/hal_stub.c
@@ -223,7 +223,7 @@ ERL_NIF_TERM hal_enumerate(ErlNifEnv *env, void *hal_priv)
         enif_make_map_put(env, line_map, atom_struct, atom_circuits_gpio_line, &line_map);
         enif_make_map_put(env, line_map, atom_controller, chip_label, &line_map);
         enif_make_map_put(env, line_map, atom_label, line_label, &line_map);
-        enif_make_map_put(env, line_map, atom_gpio_spec, enif_make_tuple2(env, chip_name, line_offset), &line_map);
+        enif_make_map_put(env, line_map, atom_location, enif_make_tuple2(env, chip_name, line_offset), &line_map);
         enif_make_map_put(env, line_map, atom_consumer, consumer, &line_map);
 
         gpio_list = enif_make_list_cell(env, line_map, gpio_list);

--- a/lib/gpio/cdev.ex
+++ b/lib/gpio/cdev.ex
@@ -47,10 +47,10 @@ defmodule Circuits.GPIO.CDev do
 
   defp find_by_tuple(gpios, {controller, label_or_index}) do
     Enum.find(gpios, fn
-      %Line{gpio_spec: {^controller, _}, label: ^label_or_index} -> true
+      %Line{location: {^controller, _}, label: ^label_or_index} -> true
       %Line{controller: ^controller, label: ^label_or_index} -> true
-      %Line{gpio_spec: {^controller, ^label_or_index}} -> true
-      %Line{controller: ^controller, gpio_spec: {_, ^label_or_index}} -> true
+      %Line{location: {^controller, ^label_or_index}} -> true
+      %Line{controller: ^controller, location: {_, ^label_or_index}} -> true
       _ -> false
     end)
   end
@@ -88,14 +88,14 @@ defmodule Circuits.GPIO.CDev do
     {:error, :not_found}
   end
 
-  defp normalize_gpio_spec({controller, line}, _options)
+  defp find_location({controller, line}, _options)
        when is_binary(controller) and is_integer(line) do
     {:ok, {controller, line}}
   end
 
-  defp normalize_gpio_spec(gpio_spec, options) do
+  defp find_location(gpio_spec, options) do
     with {:ok, line_info} <- line_info(gpio_spec, options) do
-      {:ok, line_info.gpio_spec}
+      {:ok, line_info.location}
     end
   end
 
@@ -112,9 +112,9 @@ defmodule Circuits.GPIO.CDev do
     value = Keyword.fetch!(options, :initial_value)
     pull_mode = Keyword.fetch!(options, :pull_mode)
 
-    with {:ok, normalized_spec} <- normalize_gpio_spec(gpio_spec, options),
-         resolved_spec = resolve_gpiochip(normalized_spec),
-         {:ok, ref} <- Nif.open(gpio_spec, resolved_spec, direction, value, pull_mode) do
+    with {:ok, location} <- find_location(gpio_spec, options),
+         resolved_location = resolve_gpiochip(location),
+         {:ok, ref} <- Nif.open(gpio_spec, resolved_location, direction, value, pull_mode) do
       {:ok, %__MODULE__{ref: ref}}
     end
   end

--- a/lib/gpio/line.ex
+++ b/lib/gpio/line.ex
@@ -12,20 +12,20 @@ defmodule Circuits.GPIO.Line do
 
   @derive {Inspect, optional: [:label, :controller, :consumer]}
 
-  defstruct gpio_spec: nil, label: "", controller: "", consumer: ""
+  defstruct location: nil, label: "", controller: "", consumer: ""
 
   @typedoc """
   Line information
 
-  * `:gpio_spec` - the gpio spec to pass to `GPIO.open/3` to use the GPIO
-  * `:controller` - a GPIO controller label or description. Empty string if unused
-  * `:label` - a label for the line. This could also be passed to
-    `GPIO.open/3`. Empty string if no label
+  * `:location` - a tuple that contains the controller and GPIO index on that controller
+  * `:controller` - the name or an alias for the GPIO controller. Empty string if unused
+  * `:label` - a label for the GPIO that could be passed to `GPIO.open/3`. Empty string
+    if no label
   * `:consumer` - a hint at who's using the GPIO. Empty string if unused or unknown
   """
   @type t() :: %__MODULE__{
-          gpio_spec: GPIO.gpio_spec(),
-          controller: GPIO.controller() | GPIO.label(),
+          location: {GPIO.controller(), non_neg_integer()},
+          controller: GPIO.controller(),
           label: GPIO.label(),
           consumer: String.t()
         }

--- a/test/circuits_gpio_test.exs
+++ b/test/circuits_gpio_test.exs
@@ -41,7 +41,7 @@ defmodule Circuits.GPIO2Test do
         line_info = GPIO.line_info(spec)
 
         expected_line_info = %Circuits.GPIO.Line{
-          gpio_spec: {"gpiochip0", 4},
+          location: {"gpiochip0", 4},
           label: "pair_2_0",
           controller: "stub0"
         }
@@ -56,7 +56,7 @@ defmodule Circuits.GPIO2Test do
         line_info = GPIO.line_info(spec)
 
         expected_line_info = %Circuits.GPIO.Line{
-          gpio_spec: {"gpiochip1", 1},
+          location: {"gpiochip1", 1},
           label: "pair_16_1",
           controller: "stub1"
         }
@@ -338,13 +338,13 @@ defmodule Circuits.GPIO2Test do
     assert length(result) == 64
 
     assert hd(result) == %Line{
-             gpio_spec: {"gpiochip0", 0},
+             location: {"gpiochip0", 0},
              controller: "stub0",
              label: "pair_0_0"
            }
 
     assert List.last(result) == %Line{
-             gpio_spec: {"gpiochip1", 31},
+             location: {"gpiochip1", 31},
              controller: "stub1",
              label: "pair_31_1"
            }
@@ -398,7 +398,7 @@ defmodule Circuits.GPIO2Test do
 
   test "line_info/2" do
     expected = %Circuits.GPIO.Line{
-      gpio_spec: {"gpiochip0", 5},
+      location: {"gpiochip0", 5},
       label: "pair_2_1",
       controller: "stub0"
     }
@@ -421,13 +421,13 @@ defmodule Circuits.GPIO2Test do
 
   test "refresh enumeration cache" do
     bogus_gpio = %Circuits.GPIO.Line{
-      gpio_spec: {"gpiochip10", 5},
+      location: {"gpiochip10", 5},
       label: "not_a_gpio",
       controller: "not_a_controller"
     }
 
     good_gpio = %Circuits.GPIO.Line{
-      gpio_spec: {"gpiochip1", 5},
+      location: {"gpiochip1", 5},
       label: "pair_18_1",
       controller: "stub1"
     }


### PR DESCRIPTION
The main use of gpio_spec was to describe anything that could be passed
to `open/3`. A second use was the actual controller/index tuple. Call
this second use "location" now to differentiate it.
