### PR TITLE
Remove GPIO.pin/1 and associated code

### DIFF
--- a/PORTING.md
+++ b/PORTING.md
@@ -36,6 +36,7 @@ The following breaking changes were made:
    interface. It's possible to have alternative GPIO backends now. If you have
    simple needs, the `stub` is convenient since it provides pairs of connected
    GPIOs (e.g., 0 and 1, 2 and 3, etc.).
+7. `Circuits.GPIO.pin/1` is no longer available.
 
 You should hopefully find that the semantics of API are more explicit now or at
 least the function documentation is more clear. This was necessary to support

--- a/c_src/gpio_nif.c
+++ b/c_src/gpio_nif.c
@@ -338,17 +338,6 @@ static ERL_NIF_TERM get_gpio_spec(ErlNifEnv *env, int argc, const ERL_NIF_TERM a
     return pin->gpio_spec;
 }
 
-static ERL_NIF_TERM get_pin_number(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
-{
-    struct gpio_priv *priv = enif_priv_data(env);
-    struct gpio_pin *pin;
-    if (argc != 1 ||
-            !enif_get_resource(env, argv[0], priv->gpio_pin_rt, (void**) &pin))
-        return enif_make_badarg(env);
-
-    return enif_make_int(env, pin->pin_number);
-}
-
 static ERL_NIF_TERM open_gpio(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
     struct gpio_priv *priv = enif_priv_data(env);
@@ -373,7 +362,6 @@ static ERL_NIF_TERM open_gpio(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     pin->offset = offset;
     pin->env = enif_alloc_env();
     pin->gpio_spec = enif_make_copy(pin->env, argv[0]);
-    pin->pin_number = -1; // Filled in by lower level
     pin->hal_priv = priv->hal_priv;
     pin->config.is_output = is_output;
     pin->config.trigger = TRIGGER_NONE;
@@ -440,7 +428,6 @@ static ErlNifFunc nif_funcs[] = {
     {"set_direction", 2, set_direction, 0},
     {"set_pull_mode", 2, set_pull_mode, 0},
     {"gpio_spec", 1, get_gpio_spec, 0},
-    {"pin_number", 1, get_pin_number, 0},
     {"info", 0, gpio_info, 0},
     {"enumerate", 0, gpio_enumerate, 0},
 };

--- a/c_src/gpio_nif.h
+++ b/c_src/gpio_nif.h
@@ -64,7 +64,6 @@ struct gpio_config {
 struct gpio_pin {
     char gpiochip[MAX_GPIOCHIP_PATH_LEN];
     int offset;
-    int pin_number; /* legacy pin number for backwards compatibility */
     int fd;
     void *hal_priv;
     struct gpio_config config;

--- a/lib/gpio.ex
+++ b/lib/gpio.ex
@@ -321,18 +321,6 @@ defmodule Circuits.GPIO do
   defdelegate set_pull_mode(gpio, pull_mode), to: Handle
 
   @doc """
-  Get the GPIO pin number
-
-  This function is for Circuits.GPIO v1.0 compatibility. It is recommended to
-  use other ways of identifying GPIOs going forward. See `t:gpio_spec/0`.
-  """
-  @spec pin(Handle.t()) :: non_neg_integer()
-  def pin(handle) do
-    info = Handle.info(handle)
-    info.pin_number
-  end
-
-  @doc """
   Return info about the low level GPIO interface
 
   This may be helpful when debugging issues.

--- a/lib/gpio/cdev.ex
+++ b/lib/gpio/cdev.ex
@@ -165,7 +165,7 @@ defmodule Circuits.GPIO.CDev do
 
     @impl Handle
     def info(%Circuits.GPIO.CDev{ref: ref}) do
-      %{gpio_spec: Nif.gpio_spec(ref), pin_number: Nif.pin_number(ref)}
+      %{gpio_spec: Nif.gpio_spec(ref)}
     end
   end
 end

--- a/lib/gpio/gpio_nif.ex
+++ b/lib/gpio/gpio_nif.ex
@@ -32,7 +32,6 @@ defmodule Circuits.GPIO.Nif do
   def set_direction(_gpio, _direction), do: :erlang.nif_error(:nif_not_loaded)
   def set_pull_mode(_gpio, _pull_mode), do: :erlang.nif_error(:nif_not_loaded)
   def gpio_spec(_gpio), do: :erlang.nif_error(:nif_not_loaded)
-  def pin_number(_gpio), do: :erlang.nif_error(:nif_not_loaded)
 
   def info() do
     :ok = load_nif()

--- a/lib/gpio/handle.ex
+++ b/lib/gpio/handle.ex
@@ -14,10 +14,7 @@ defprotocol Circuits.GPIO.Handle do
   # Information about the GPIO
   #
   # * `:gpio_spec` - the spec that was used to open the GPIO
-  # * `:pin_number` - the legacy pin number for the GPIO. This is for backwards
-  #   compatibility and could be set to `0` if there's no easy way to assign a
-  #   unique number to it.
-  @typep info() :: %{gpio_spec: GPIO.gpio_spec(), pin_number: non_neg_integer()}
+  @typep info() :: %{gpio_spec: GPIO.gpio_spec()}
 
   # Return the current GPIO state
   @doc false

--- a/test/circuits_gpio_test.exs
+++ b/test/circuits_gpio_test.exs
@@ -93,18 +93,6 @@ defmodule Circuits.GPIO2Test do
     assert GPIO.info().pins_open == 0
   end
 
-  test "can get the pin number" do
-    {:ok, gpio} = GPIO.open({@gpiochip, 10}, :output)
-    assert GPIO.pin(gpio) == 10
-    GPIO.close(gpio)
-  end
-
-  test "open by pin number returns expected pin number" do
-    {:ok, gpio} = GPIO.open(12, :output)
-    assert GPIO.pin(gpio) == 12
-    GPIO.close(gpio)
-  end
-
   test "open returns errors on invalid pins" do
     # The stub returns error on any pin numbers >= 64
     assert GPIO.open({@gpiochip, 100}, :input) == {:error, :not_found}


### PR DESCRIPTION
It wasn't implemented for the cdev backend, and I really don't think it
was that useful anyway.
