### PR TITLE
Add gpio_status/1 function to get runtime info

### DIFF
--- a/c_src/gpio_nif.h
+++ b/c_src/gpio_nif.h
@@ -186,6 +186,17 @@ int hal_apply_interrupts(struct gpio_pin *pin, ErlNifEnv *env);
  */
 int hal_apply_pull_mode(struct gpio_pin *pin);
 
+/**
+ * Return a map that has runtime information about a GPIO
+ *
+ * @param env a NIF environment for making the map
+ * @param gpiochip which controller
+ * @param offset the offset on the controller
+ * @param result where to store the result when successful
+ * @return 0 on success, -errno on failure
+ */
+int hal_get_gpio_status(void *hal_priv, ErlNifEnv *env, const char *gpiochip, int offset, ERL_NIF_TERM *result);
+
 // nif_utils.c
 ERL_NIF_TERM make_ok_tuple(ErlNifEnv *env, ERL_NIF_TERM value);
 ERL_NIF_TERM make_errno_error(ErlNifEnv *env, int errno_value);

--- a/lib/gpio.ex
+++ b/lib/gpio.ex
@@ -102,7 +102,7 @@ defmodule Circuits.GPIO do
   @type pull_mode() :: :not_set | :none | :pullup | :pulldown
 
   @typedoc """
-  GPIO information
+  Static GPIO information
 
   Location and other static information about a GPIO that is returned by
   `enumerate/1`.  Backends must provide `:location` which is an unambiguous
@@ -122,6 +122,22 @@ defmodule Circuits.GPIO do
           location: {controller(), non_neg_integer()},
           controller: controller(),
           label: label()
+        }
+
+  @typedoc """
+  Dynamic GPIO configuration and status
+
+  Fields:
+
+  * `:consumer` - if this GPIO is in use, this optional string gives a hint as to who is
+    using it.
+  * `:direction` - whether this GPIO is an input or output
+  * `:pull_mode` - if this GPIO is an input, then this is the pull mode
+  """
+  @type gpio_status() :: %{
+          consumer: String.t(),
+          direction: direction(),
+          pull_mode: pull_mode()
         }
 
   @typedoc """
@@ -165,7 +181,7 @@ defmodule Circuits.GPIO do
   def gpio_spec?(x), do: is_gpio_spec(x)
 
   @doc """
-  Return information about a GPIO
+  Return static information about a GPIO
 
   See `t:gpio_spec/0` for the ways of referring to GPIOs. If the GPIO is found,
   this function returns information about the GPIO.
@@ -175,6 +191,19 @@ defmodule Circuits.GPIO do
     {backend, backend_defaults} = default_backend()
 
     backend.gpio_info(gpio_spec, backend_defaults)
+  end
+
+  @doc """
+  Return dynamic configuration and status information about a GPIO
+
+  See `t:gpio_spec/0` for the ways of referring to GPIOs. If the GPIO is found,
+  this function returns information about the GPIO.
+  """
+  @spec gpio_status(gpio_spec()) :: {:ok, gpio_status()} | {:error, atom()}
+  def gpio_status(gpio_spec) do
+    {backend, backend_defaults} = default_backend()
+
+    backend.gpio_status(gpio_spec, backend_defaults)
   end
 
   @doc """

--- a/lib/gpio/backend.ex
+++ b/lib/gpio/backend.ex
@@ -31,6 +31,24 @@ defmodule Circuits.GPIO.Backend do
             ) :: {:ok, GPIO.gpio_info()} | {:error, atom()}
 
   @doc """
+  Return a GPIO's current status
+
+  This function returns how a GPIO is configured. The GPIO doesn't need to be
+  opened. It's different from `gpio_info/2` since it returns dynamic information
+  whereas `gpio_info/2` only returns information about how to refer to a GPIO
+  and where it exists in the system.
+
+  See `t:gpio_spec/0` for the ways of referring to GPIOs. The `options` contain
+  backend-specific options to help enumerating GPIOs.
+
+  If the GPIO is found, this function returns its status.
+  """
+  @callback gpio_status(
+              gpio_spec :: GPIO.gpio_spec(),
+              options :: GPIO.open_options()
+            ) :: {:ok, GPIO.gpio_status()} | {:error, atom()}
+
+  @doc """
   Open a GPIO
 
   See `t:gpio_spec/0` for the ways of referring to GPIOs. Set `direction` to

--- a/lib/gpio/handle.ex
+++ b/lib/gpio/handle.ex
@@ -11,11 +11,6 @@ defprotocol Circuits.GPIO.Handle do
 
   alias Circuits.GPIO
 
-  # Information about the GPIO
-  #
-  # * `:gpio_spec` - the spec that was used to open the GPIO
-  @typep info() :: %{gpio_spec: GPIO.gpio_spec()}
-
   # Return the current GPIO state
   @doc false
   @spec read(t()) :: GPIO.value()
@@ -49,8 +44,4 @@ defprotocol Circuits.GPIO.Handle do
   @doc false
   @spec set_interrupts(t(), GPIO.trigger(), GPIO.interrupt_options()) :: :ok | {:error, atom()}
   def set_interrupts(handle, trigger, options)
-
-  @doc false
-  @spec info(t()) :: info()
-  def info(handle)
 end

--- a/lib/gpio/nil_backend.ex
+++ b/lib/gpio/nil_backend.ex
@@ -21,6 +21,11 @@ defmodule Circuits.GPIO.NilBackend do
   end
 
   @impl Backend
+  def gpio_status(_gpio_spec, _options) do
+    {:error, :not_found}
+  end
+
+  @impl Backend
   def open(_gpio_spec, _direction, _options) do
     {:error, :unimplemented}
   end

--- a/test/circuits_gpio_test.exs
+++ b/test/circuits_gpio_test.exs
@@ -83,6 +83,55 @@ defmodule Circuits.GPIO2Test do
     end
   end
 
+  describe "gpio_status/2" do
+    test "all gpio_spec examples" do
+      expected = %{consumer: "", direction: :input, pull_mode: :none}
+
+      assert GPIO.gpio_status(5) == {:ok, expected}
+      assert GPIO.gpio_status("pair_2_1") == {:ok, expected}
+      assert GPIO.gpio_status({"gpiochip0", 5}) == {:ok, expected}
+      assert GPIO.gpio_status({"stub0", 5}) == {:ok, expected}
+      assert GPIO.gpio_status({"gpiochip0", "pair_2_1"}) == {:ok, expected}
+      assert GPIO.gpio_status({"stub0", "pair_2_1"}) == {:ok, expected}
+
+      assert GPIO.gpio_status(-1) == {:error, :not_found}
+      assert GPIO.gpio_status(64) == {:error, :not_found}
+      assert GPIO.gpio_status("something") == {:error, :not_found}
+      assert GPIO.gpio_status({"gpiochip0", 64}) == {:error, :not_found}
+      assert GPIO.gpio_status({"stub0", 64}) == {:error, :not_found}
+      assert GPIO.gpio_status({"gpiochip0", "something"}) == {:error, :not_found}
+      assert GPIO.gpio_status({"stub0", "something"}) == {:error, :not_found}
+    end
+
+    test "status reports output gpio" do
+      {:ok, gpio} = GPIO.open({@gpiochip, 1}, :output)
+
+      assert GPIO.gpio_status({@gpiochip, 1}) ==
+               {:ok,
+                %{
+                  consumer: "stub",
+                  direction: :output,
+                  pull_mode: :none
+                }}
+
+      GPIO.close(gpio)
+    end
+
+    test "status reports input gpio" do
+      {:ok, gpio} = GPIO.open({@gpiochip, 1}, :input, pull_mode: :pullup)
+
+      assert GPIO.gpio_status({@gpiochip, 1}) ==
+               {:ok,
+                %{
+                  consumer: "stub",
+                  direction: :input,
+                  pull_mode: :pullup
+                }}
+
+      GPIO.close(gpio)
+    end
+  end
+
   test "opening and closing a pin gets counted" do
     {:ok, gpio} = GPIO.open({@gpiochip, 1}, :input)
     assert is_struct(gpio, Circuits.GPIO.CDev)


### PR DESCRIPTION
Once `gpio_info/1` got limited to static information, there wasn't a way
to get runtime configuration and other info. This lets you do that now
and populates the information with consumer, direction and pull mode. It
could be expanded in the future.

This also fixes an issue were `open/3` didn't handle controller labels
with integer offsets.
