### PR TITLE
Fix race to load NIF

### DIFF
--- a/c_src/gpio_nif.c
+++ b/c_src/gpio_nif.c
@@ -34,7 +34,6 @@ static void release_gpio_pin(struct gpio_priv *priv, struct gpio_pin *pin)
     }
     if (pin->fd >= 0) {
         hal_close_gpio(pin);
-        priv->pins_open--;
         pin->fd = -1;
     }
 }
@@ -123,7 +122,6 @@ static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM info)
         return 1;
     }
 
-    priv->pins_open = 0;
     priv->gpio_pin_rt = enif_open_resource_type_x(env, "gpio_pin", &gpio_pin_init, ERL_NIF_RT_CREATE, NULL);
 
     if (hal_load(&priv->hal_priv) < 0) {
@@ -385,8 +383,6 @@ static ERL_NIF_TERM open_gpio(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     ERL_NIF_TERM pin_resource = enif_make_resource(env, pin);
     enif_release_resource(pin);
 
-    priv->pins_open++;
-
     return make_ok_tuple(env, pin_resource);
 }
 
@@ -410,8 +406,6 @@ static ERL_NIF_TERM backend_info(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
 
     struct gpio_priv *priv = enif_priv_data(env);
     ERL_NIF_TERM info = enif_make_new_map(env);
-
-    enif_make_map_put(env, info, enif_make_atom(env, "pins_open"), enif_make_int(env, priv->pins_open), &info);
 
     return hal_info(env, priv->hal_priv, info);
 }

--- a/c_src/gpio_nif.h
+++ b/c_src/gpio_nif.h
@@ -47,8 +47,6 @@ enum pull_mode {
 struct gpio_priv {
     ErlNifResourceType *gpio_pin_rt;
 
-    int pins_open;
-
     uint32_t hal_priv[1];
 };
 

--- a/test/circuits_gpio_test.exs
+++ b/test/circuits_gpio_test.exs
@@ -482,4 +482,21 @@ defmodule Circuits.GPIO2Test do
     assert GPIO.write_one({@gpiochip, 1}, 1) == :ok
     assert GPIO.read_one({@gpiochip, 0}) == 1
   end
+
+  test "racing to load the NIF" do
+    # Make sure the NIF isn't loaded
+    assert true == :code.delete(Circuits.GPIO.Nif)
+    assert false == :code.purge(Circuits.GPIO.Nif)
+
+    # Try to hit the race by having 32 processes race to load the NIF
+    tasks =
+      for index <- 0..31 do
+        Task.async(fn ->
+          {:ok, gpio} = GPIO.open({@gpiochip, index}, :input)
+          GPIO.close(gpio)
+        end)
+      end
+
+    Enum.each(tasks, &Task.await/1)
+  end
 end


### PR DESCRIPTION
This happens when multiple processes call GPIO.open at the same time.
NIFs can only be loaded once only one process gets an `:ok` return. The
others get an error telling them not to do that. That's harmless so just
try calling the function again.

The included unit test starts 32 processes in a race to open the GPIO.
On my MBP, a whole bunch of the processes would get the reload error
before the fix.

Fixes #178
