### PR TITLE
Fix race to load NIF

### DIFF
--- a/c_src/gpio_nif.c
+++ b/c_src/gpio_nif.c
@@ -20,7 +20,6 @@ static void release_gpio_pin(struct gpio_priv *priv, struct gpio_pin *pin)
 {
     if (pin->fd >= 0) {
         hal_close_gpio(pin);
-        priv->pins_open--;
         pin->fd = -1;
     }
 }
@@ -104,7 +103,6 @@ static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM info)
         return 1;
     }
 
-    priv->pins_open = 0;
     priv->gpio_pin_rt = enif_open_resource_type_x(env, "gpio_pin", &gpio_pin_init, ERL_NIF_RT_CREATE, NULL);
 
     if (hal_load(&priv->hal_priv) < 0) {
@@ -331,8 +329,6 @@ static ERL_NIF_TERM open_gpio(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     ERL_NIF_TERM pin_resource = enif_make_resource(env, pin);
     enif_release_resource(pin);
 
-    priv->pins_open++;
-
     return make_ok_tuple(env, pin_resource);
 }
 
@@ -355,8 +351,6 @@ static ERL_NIF_TERM gpio_info(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
 
     struct gpio_priv *priv = enif_priv_data(env);
     ERL_NIF_TERM info = enif_make_new_map(env);
-
-    enif_make_map_put(env, info, enif_make_atom(env, "pins_open"), enif_make_int(env, priv->pins_open), &info);
 
     return hal_info(env, priv->hal_priv, info);
 }

--- a/c_src/gpio_nif.h
+++ b/c_src/gpio_nif.h
@@ -46,8 +46,6 @@ enum pull_mode {
 struct gpio_priv {
     ErlNifResourceType *gpio_pin_rt;
 
-    int pins_open;
-
     uint32_t hal_priv[1];
 };
 

--- a/lib/gpio/gpio_nif.ex
+++ b/lib/gpio/gpio_nif.ex
@@ -5,16 +5,19 @@
 defmodule Circuits.GPIO.Nif do
   @moduledoc false
 
-  defp load_nif() do
+  defp load_nif_and_apply(fun, args) do
     nif_binary = Application.app_dir(:circuits_gpio, "priv/gpio_nif")
 
-    :erlang.load_nif(to_charlist(nif_binary), 0)
+    # Optimistically load the NIF. Handle the possible race.
+    case :erlang.load_nif(to_charlist(nif_binary), 0) do
+      :ok -> apply(__MODULE__, fun, args)
+      {:error, {:reload, _}} -> apply(__MODULE__, fun, args)
+      error -> error
+    end
   end
 
   def open(pin_number, pin_direction, initial_value, pull_mode) do
-    with :ok <- load_nif() do
-      apply(__MODULE__, :open, [pin_number, pin_direction, initial_value, pull_mode])
-    end
+    load_nif_and_apply(:open, [pin_number, pin_direction, initial_value, pull_mode])
   end
 
   def close(_gpio) do
@@ -46,7 +49,6 @@ defmodule Circuits.GPIO.Nif do
   end
 
   def info() do
-    :ok = load_nif()
-    apply(__MODULE__, :info, [])
+    load_nif_and_apply(:info, [])
   end
 end


### PR DESCRIPTION
This happens when multiple processes call GPIO.open at the same time.
NIFs can only be loaded once only one process gets an `:ok` return. The
others get an error telling them not to do that. That's harmless so just
try calling the function again.

The included unit test starts 32 processes in a race to open the GPIO.
On my MBP, a whole bunch of the processes would get the reload error
before the fix.

Fixes #178
