### PR TITLE
update documentation for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,27 +7,6 @@
 
 `Circuits.GPIO` lets you use GPIOs in Elixir.
 
-*This is the v2.0 development branch. If you're still using v1, please see the [maint-v1.x branch](https://github.com/elixir-circuits/circuits_gpio/tree/maint-v1.x).*
-
-`Circuits.GPIO` v2.0  is an almost backwards compatible update to `Circuits.GPIO`
-v1.x. Here's what's new:
-
-* Linux or Nerves are no longer required. In fact, the NIF supporting them won't
-  be compiled if you don't want it.
-* GPIOs can be enumerated to see what's available (See `Circuits.GPIO.enumerate/0`)
-* Linux and Nerves now use the Linux GPIO cdev subsystem rather than sysfs
-* GPIO pull mode setting for all platforms that support it rather than only Raspberry Pi
-* Develop using simulated GPIOs to work with LEDs and buttons with
-  [CircuitsSim](https://github.com/elixir-circuits/circuits_sim)
-
-If you've used `Circuits.GPIO` v1.x, nearly all of your code will be the
-same.`Circuits.GPIO` offers a substantial improvement by more descriptive GPIO
-specs for identifying GPIOs. You can still refer to GPIOs by number. However,
-you can also refer to GPIOs by labels and by which GPIO controller handles them.
-The new `enumerate/0` can help with this.
-
-Please review the [porting guide](PORTING.md) when upgrading from v1.x.
-
 ## Getting started on Nerves and Linux
 
 If you're natively compiling `circuits_gpio` using Nerves or using a Linux-based
@@ -291,6 +270,31 @@ The stub HAL is fairly limited, but it does support interrupts.
 If `Circuits.GPIO` is used as a dependency the stub may not be present. To
 manually enable it, set `CIRCUITS_MIX_ENV` to `test` and rebuild
 `circuits_gpio`.
+
+## Migration from v1.x
+
+v2.x is the current version of `Circuits.GPIO`.
+
+`Circuits.GPIO` v2.0 is an almost backwards compatible update to `Circuits.GPIO`
+v1.x. Here's what's new:
+
+* Linux or Nerves are no longer required. In fact, the NIF supporting them won't
+  be compiled if you don't want it.
+* GPIOs can be enumerated to see what's available (See `Circuits.GPIO.enumerate/0`)
+* Linux and Nerves now use the Linux GPIO cdev subsystem rather than sysfs
+* GPIO pull mode setting for all platforms that support it rather than only Raspberry Pi
+* Develop using simulated GPIOs to work with LEDs and buttons with
+  [CircuitsSim](https://github.com/elixir-circuits/circuits_sim)
+
+If you've used `Circuits.GPIO` v1.x, nearly all of your code will be the
+same.`Circuits.GPIO` offers a substantial improvement by more descriptive GPIO
+specs for identifying GPIOs. You can still refer to GPIOs by number. However,
+you can also refer to GPIOs by labels and by which GPIO controller handles them.
+The new `enumerate/0` can help with this.
+
+If you are using a previous version and wish to update, review the [porting
+guide](PORTING.md). Also see [circuits_gpio v1.x maintenance
+branch](https://github.com/elixir-circuits/circuits_gpio/tree/maint-v1.x).
 
 ## FAQ
 


### PR DESCRIPTION
### Description

This is a proposal for organizing migration guides. It mainly addresses two things.

1. Outdated contents in README.md
2. Introducing a new directory that holds our guides including migration instructions

### Outdated contents in README.md

- README.md still talks as if v2 had not been released yet. So it needs updating.

![circuits_gpio_v2_readme_2024-01-13 at 18 01 01](https://github.com/elixir-circuits/circuits_gpio/assets/7563926/f7452de5-7644-4308-bd1a-a0b8dacdf806)

### Organization of our migration guides

- Currently our upgrade guides are located in two files:
  1. README.md
  3. PORTING.md
- Some projects out there seem to have a dedicated directory for "guides",
  which we could try now that we have more than one migration concerns

### Notes

- The contents are mostly unchanged; basically they are just moved around
- Once we decide to go ahead, we will have to check the hyperlinks to `PORTING.md` since it is referenced in a few places; also included files in the package might need adjustment

