### PR TITLE
Improve target detection for building cdev

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -94,8 +94,16 @@ defmodule Circuits.GPIO.MixProject do
     end
   end
 
-  # Assume Nerves for a default
-  defp default_backend(_env, _not_host), do: Circuits.GPIO.CDev
+  # MIX_TARGET set to something besides host
+  defp default_backend(env, _not_host) do
+    # If CROSSCOMPILE is set, then the Makefile will use the crosscompiler and
+    # assume a Linux/Nerves build If not, then the NIF will be build for the
+    # host, so use the default host backend
+    case System.fetch_env("CROSSCOMPILE") do
+      {:ok, _} -> Circuits.GPIO.CDev
+      :error -> default_backend(env, :host)
+    end
+  end
 
   defp make_env() do
     # Since user configuration hasn't been loaded into the application


### PR DESCRIPTION
It turns out that people sometimes have MIX_TARGET set when they're not
compiling for Nerves. On MacOS which doesn't support cdev, this causes
the following error:

```
==> circuits_gpio
"**** CIRCUITS_GPIO_BACKEND set to [cdev] ****"
Makefile:44: *** Circuits.GPIO Linux cdev backend is not supported on non-Linux platforms. Review circuits_gpio backend configuration or report an issue if improperly detected..  Stop.
could not compile dependency :circuits_gpio, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile circuits_gpio --force", update it with "mix deps.update circuits_gpio" or clean it with "mix deps.clean circuits_gpio"
```

This is pretty confusing. This change makes the Nerves detection smarter
by first checking the MIX_TARGET and then checking if crosscompilation
environment variables are actually set. If not, the host compiler will
be used, so use the default for host builds.
