### PR TITLE
Add `:drive_mode` option to support open drain and open source modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,23 @@ pull-down is between 50K and 60K.  It is not possible to read back the current
 Pull-up/down settings, and GPIO pull-up pull-down resistor connections are
 maintained, even when the CPU is powered down.
 
+### GPIO drive mode
+
+To configure how an output GPIO pin is driven, call the `set_drive_mode`
+function:
+
+```elixir
+iex> Circuits.GPIO.set_drive_mode(gpio, :open_drain)
+:ok
+```
+
+Valid `drive_mode` values are `:push_pull`, `:open_drain`, or `:open_source`.
+
+The `:push_pull` drive mode is the default and drives the pin high or low
+actively. The `:open_drain` and `:open_source` only pull a line to low or high,
+respectively, and other states leave the line floating. Read more about open
+drain and open source [here](https://en.wikipedia.org/wiki/Open_collector)
+
 ## GPIO Specs
 
 `Circuits.GPIO` v2.0 supports a new form of specifying how to open a GPIO called

--- a/c_src/gpio_nif.c
+++ b/c_src/gpio_nif.c
@@ -258,6 +258,20 @@ static int get_pull_mode(ErlNifEnv *env, ERL_NIF_TERM term, enum pull_mode *pull
     return true;
 }
 
+static int get_drive_mode(ErlNifEnv *env, ERL_NIF_TERM term, enum drive_mode *drive)
+{
+    char buffer[16];
+    if (!enif_get_atom(env, term, buffer, sizeof(buffer), ERL_NIF_LATIN1))
+        return false;
+
+    if (strcmp("push_pull", buffer) == 0) *drive = DRIVE_PUSH_PULL;
+    else if (strcmp("open_drain", buffer) == 0) *drive = DRIVE_OPEN_DRAIN;
+    else if (strcmp("open_source", buffer) == 0) *drive = DRIVE_OPEN_SOURCE;
+    else return false;
+
+    return true;
+}
+
 static ERL_NIF_TERM set_interrupts(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
     struct gpio_priv *priv = enif_priv_data(env);
@@ -328,6 +342,28 @@ static ERL_NIF_TERM set_pull_mode(ErlNifEnv *env, int argc, const ERL_NIF_TERM a
     return atom_ok;
 }
 
+static ERL_NIF_TERM set_drive_mode(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    struct gpio_priv *priv = enif_priv_data(env);
+    struct gpio_pin *pin;
+
+    if (argc != 2 ||
+            !enif_get_resource(env, argv[0], priv->gpio_pin_rt, (void**) &pin))
+        return enif_make_badarg(env);
+
+    struct gpio_config old_config = pin->config;
+    if (!get_drive_mode(env, argv[1], &pin->config.drive))
+        return enif_make_badarg(env);
+
+    int rc = hal_apply_drive_mode(pin);
+    if (rc < 0) {
+        pin->config = old_config;
+        return make_errno_error(env, rc);
+    }
+
+    return atom_ok;
+}
+
 static ERL_NIF_TERM get_status(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
     struct gpio_priv *priv = enif_priv_data(env);
@@ -352,13 +388,15 @@ static ERL_NIF_TERM open_gpio(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     int offset;
     int initial_value;
     enum pull_mode pull;
+    enum drive_mode drive;
     char gpiochip_path[MAX_GPIOCHIP_PATH_LEN];
 
-    if (argc != 5 ||
+    if (argc != 6 ||
             !get_resolved_location(env, argv[1], gpiochip_path, &offset) ||
             !get_direction(env, argv[2], &is_output) ||
             !get_value(env, argv[3], &initial_value) ||
-            !get_pull_mode(env, argv[4], &pull))
+            !get_pull_mode(env, argv[4], &pull) ||
+            !get_drive_mode(env, argv[5], &drive))
         return enif_make_badarg(env);
 
     debug("open {%s, %d}", gpiochip_path, offset);
@@ -373,6 +411,7 @@ static ERL_NIF_TERM open_gpio(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     pin->config.is_output = is_output;
     pin->config.trigger = TRIGGER_NONE;
     pin->config.pull = pull;
+    pin->config.drive = drive;
     pin->config.suppress_glitches = false;
     pin->config.initial_value = initial_value;
 
@@ -424,13 +463,14 @@ static ERL_NIF_TERM gpio_enumerate(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
 }
 
 static ErlNifFunc nif_funcs[] = {
-    {"open", 5, open_gpio, ERL_NIF_DIRTY_JOB_IO_BOUND},
+    {"open", 6, open_gpio, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"close", 1, close_gpio, 0},
     {"read", 1, read_gpio, 0},
     {"write", 2, write_gpio, 0},
     {"set_interrupts", 4, set_interrupts, 0},
     {"set_direction", 2, set_direction, 0},
     {"set_pull_mode", 2, set_pull_mode, 0},
+    {"set_drive_mode", 2, set_drive_mode, 0},
     {"status", 1, get_status, 0},
     {"backend_info", 0, backend_info, 0},
     {"enumerate", 0, gpio_enumerate, 0}

--- a/c_src/gpio_nif.h
+++ b/c_src/gpio_nif.h
@@ -46,6 +46,12 @@ enum pull_mode {
     PULL_DOWN
 };
 
+enum drive_mode {
+    DRIVE_PUSH_PULL,
+    DRIVE_OPEN_DRAIN,
+    DRIVE_OPEN_SOURCE
+};
+
 struct gpio_priv {
     ErlNifResourceType *gpio_pin_rt;
 
@@ -56,6 +62,7 @@ struct gpio_config {
     bool is_output;
     enum trigger_mode trigger;
     enum pull_mode pull;
+    enum drive_mode drive;
     bool suppress_glitches;
     int initial_value;
     ErlNifPid pid;
@@ -185,6 +192,14 @@ int hal_apply_interrupts(struct gpio_pin *pin, ErlNifEnv *env);
  * @return 0 on success
  */
 int hal_apply_pull_mode(struct gpio_pin *pin);
+
+/**
+ * Apply GPIO drive mode settings
+ *
+ * @param pin which one
+ * @return 0 on success
+ */
+int hal_apply_drive_mode(struct gpio_pin *pin);
 
 /**
  * Return a map that has runtime information about a GPIO

--- a/c_src/hal_cdev_gpio.c
+++ b/c_src/hal_cdev_gpio.c
@@ -116,6 +116,18 @@ static uint64_t config_to_flags(const struct gpio_pin *pin)
         break;
     }
 
+    switch (pin->config.drive) {
+    case DRIVE_OPEN_DRAIN:
+        flags |= GPIO_V2_LINE_FLAG_OPEN_DRAIN;
+        break;
+    case DRIVE_OPEN_SOURCE:
+        flags |= GPIO_V2_LINE_FLAG_OPEN_SOURCE;
+        break;
+    case DRIVE_PUSH_PULL:
+    default:
+        break;
+    }
+
     switch (pin->config.trigger) {
     case TRIGGER_RISING:
         flags |= GPIO_V2_LINE_FLAG_EDGE_RISING;
@@ -316,6 +328,12 @@ int hal_apply_pull_mode(struct gpio_pin *pin)
     return refresh_config(pin);
 }
 
+int hal_apply_drive_mode(struct gpio_pin *pin)
+{
+    debug("hal_apply_drive_mode %s:%d", pin->gpiochip, pin->offset);
+    return refresh_config(pin);
+}
+
 ERL_NIF_TERM hal_enumerate(ErlNifEnv *env, void *hal_priv)
 {
     int i;
@@ -387,11 +405,20 @@ int hal_get_status(void *hal_priv, ErlNifEnv *env, const char *gpiochip, int off
     else
         pull_mode_str = "none";
 
+    const char *drive_mode_str;
+    if (line.flags & GPIO_V2_LINE_FLAG_OPEN_DRAIN)
+        drive_mode_str = "open_drain";
+    else if (line.flags & GPIO_V2_LINE_FLAG_OPEN_SOURCE)
+        drive_mode_str = "open_source";
+    else
+        drive_mode_str = "push_pull";
+
     ERL_NIF_TERM map = enif_make_new_map(env);
     ERL_NIF_TERM consumer = make_string_binary(env, line.consumer);
     enif_make_map_put(env, map, atom_consumer, consumer, &map);
     enif_make_map_put(env, map, enif_make_atom(env, "direction"), enif_make_atom(env, is_output ? "output" : "input"), &map);
     enif_make_map_put(env, map, enif_make_atom(env, "pull_mode"), enif_make_atom(env, pull_mode_str), &map);
+    enif_make_map_put(env, map, enif_make_atom(env, "drive_mode"), enif_make_atom(env, drive_mode_str), &map);
 
     *result = map;
     return 0;

--- a/c_src/hal_stub.c
+++ b/c_src/hal_stub.c
@@ -215,6 +215,12 @@ int hal_apply_pull_mode(struct gpio_pin *pin)
     return 0;
 }
 
+int hal_apply_drive_mode(struct gpio_pin *pin)
+{
+    (void) pin;
+    return 0;
+}
+
 ERL_NIF_TERM hal_enumerate(ErlNifEnv *env, void *hal_priv)
 {
     ERL_NIF_TERM gpio_list = enif_make_list(env, 0);

--- a/c_src/hal_stub.c
+++ b/c_src/hal_stub.c
@@ -172,13 +172,28 @@ int hal_write_gpio(struct gpio_pin *pin, int value, ErlNifEnv *env)
     struct stub_priv *stub_priv = pin->hal_priv;
     int our_pin = pin->fd;
     int other_pin = our_pin ^ 1;
-    if (stub_priv->value[our_pin] != value) {
-        stub_priv->value[our_pin] = value;
-        maybe_send_notification(env, stub_priv->gpio_pins[our_pin], value);
+
+    // When drive_mode is :open_drain or :open_source, we need to first determine if the
+    // output is hi-Z (which is modeled by a value of -1)
+    bool is_open_drain = pin->config.drive == DRIVE_OPEN_DRAIN;
+    bool is_open_source = pin->config.drive == DRIVE_OPEN_SOURCE;
+
+    int target_value;
+    if (is_open_drain && value == 1) {
+        target_value = -1;
+    } else if (is_open_source && value == 0) {
+        target_value = -1;
+    } else {
+        target_value = value;
+    }
+
+    if (stub_priv->value[our_pin] != target_value) {
+        stub_priv->value[our_pin] = target_value;
+        maybe_send_notification(env, stub_priv->gpio_pins[our_pin], target_value);
 
         // Only notify other pin if it's not outputting a value.
         if (stub_priv->value[other_pin] == -1)
-            maybe_send_notification(env, stub_priv->gpio_pins[other_pin], value);
+            maybe_send_notification(env, stub_priv->gpio_pins[other_pin], target_value);
     }
     return 0;
 }
@@ -277,6 +292,7 @@ int hal_get_status(void *hal_priv, ErlNifEnv *env, const char *gpiochip, int off
 
     struct gpio_pin *pin = stub_priv->gpio_pins[pin_index];
     const char *pull_mode_str;
+    const char *drive_mode_str;
     int is_output;
     if (pin) {
         switch (pin->config.pull) {
@@ -290,15 +306,30 @@ int hal_get_status(void *hal_priv, ErlNifEnv *env, const char *gpiochip, int off
             pull_mode_str = "none";
             break;
         }
+
+        switch (pin->config.drive) {
+        case DRIVE_OPEN_DRAIN:
+            drive_mode_str = "open_drain";
+            break;
+        case DRIVE_OPEN_SOURCE:
+            drive_mode_str = "open_source";
+            break;
+        default:
+            drive_mode_str = "push_pull";
+            break;
+        }
+
         is_output = pin->config.is_output;
     } else {
         is_output = 0;
         pull_mode_str = "none";
+        drive_mode_str = "push_pull";
     }
 
     enif_make_map_put(env, map, atom_consumer, consumer, &map);
     enif_make_map_put(env, map, enif_make_atom(env, "direction"), enif_make_atom(env, is_output ? "output" : "input"), &map);
     enif_make_map_put(env, map, enif_make_atom(env, "pull_mode"), enif_make_atom(env, pull_mode_str), &map);
+    enif_make_map_put(env, map, enif_make_atom(env, "drive_mode"), enif_make_atom(env, drive_mode_str), &map);
 
     *result = map;
     return 0;

--- a/lib/gpio.ex
+++ b/lib/gpio.ex
@@ -109,6 +109,9 @@ defmodule Circuits.GPIO do
   @typedoc "Pull mode for platforms that support controllable pullups and pulldowns"
   @type pull_mode() :: :not_set | :none | :pullup | :pulldown
 
+  @typedoc "Drive mode for platforms that support push-pull, open-drain, and open-source"
+  @type drive_mode() :: :push_pull | :open_drain | :open_source
+
   @typedoc """
   Ways of referring to a GPIO
 
@@ -147,11 +150,13 @@ defmodule Circuits.GPIO do
     using it.
   * `:direction` - whether this GPIO is an input or output
   * `:pull_mode` - if this GPIO is an input, then this is the pull mode
+  * `:drive_mode` - how the GPIO is driven (push-pull, open-drain, or open-source)
   """
   @type status() :: %{
           consumer: String.t(),
           direction: direction(),
-          pull_mode: pull_mode()
+          pull_mode: pull_mode(),
+          drive_mode: drive_mode()
         }
 
   @typedoc """
@@ -159,6 +164,7 @@ defmodule Circuits.GPIO do
 
   * `:initial_value` - the initial value of an output GPIO
   * `:pull_mode` - the initial pull mode for an input GPIO
+  * `:drive_mode` - the drive mode of an output GPIO
   * `:force_enumeration` - Linux cdev-specific option to force a scan of
     available GPIOs rather than using the cache. This is only for test purposes
     since the GPIO cache should refresh as needed.
@@ -166,6 +172,7 @@ defmodule Circuits.GPIO do
   @type open_options() :: [
           initial_value: value(),
           pull_mode: pull_mode(),
+          drive_mode: drive_mode(),
           force_enumeration: boolean()
         ]
 
@@ -236,6 +243,8 @@ defmodule Circuits.GPIO do
   * :initial_value - Set to `0` or `1`. Only used for outputs. Defaults to `0`.
   * :pull_mode - Set to `:not_set`, `:pullup`, `:pulldown`, or `:none` for an
      input pin. `:not_set` is the default.
+  * :drive_mode - Set to `:push_pull`, `:open_drain`, or `:open_source`.
+     `:push_pull` is the default. Only used for outputs.
 
   Returns `{:ok, handle}` on success.
   """
@@ -259,6 +268,7 @@ defmodule Circuits.GPIO do
       |> Keyword.merge(options)
       |> Keyword.put_new(:initial_value, 0)
       |> Keyword.put_new(:pull_mode, :not_set)
+      |> Keyword.put_new(:drive_mode, :push_pull)
 
     backend.open(gpio_spec, direction, all_options)
   end
@@ -292,6 +302,13 @@ defmodule Circuits.GPIO do
   defp check_options!([{:pull_mode, value} | rest]) do
     if value not in [:not_set, :pullup, :pulldown, :none],
       do: raise(ArgumentError, ":pull_mode should be :not_set, :pullup, :pulldown, or :none")
+
+    check_options!(rest)
+  end
+
+  defp check_options!([{:drive_mode, value} | rest]) do
+    if value not in [:push_pull, :open_drain, :open_source],
+      do: raise(ArgumentError, ":drive_mode should be :push_pull, :open_drain, or :open_source")
 
     check_options!(rest)
   end
@@ -409,6 +426,12 @@ defmodule Circuits.GPIO do
   """
   @spec set_pull_mode(Handle.t(), pull_mode()) :: :ok | {:error, atom()}
   defdelegate set_pull_mode(gpio, pull_mode), to: Handle
+
+  @doc """
+  Set the drive mode (push-pull, open-drain, or open-source)
+  """
+  @spec set_drive_mode(Handle.t(), drive_mode()) :: :ok | {:error, atom()}
+  defdelegate set_drive_mode(gpio, drive_mode), to: Handle
 
   @doc """
   Return info about the low level GPIO interface

--- a/lib/gpio/backend.ex
+++ b/lib/gpio/backend.ex
@@ -62,6 +62,8 @@ defmodule Circuits.GPIO.Backend do
   * :initial_value - Set to `0` or `1`. Only used for outputs. Defaults to `0`.
   * :pull_mode - Set to `:not_set`, `:pullup`, `:pulldown`, or `:none` for an
      input pin. `:not_set` is the default.
+  * :drive_mode - Set to `:push_pull`, `:open_drain`, or `:open_source`.
+     `:push_pull` is the default.
 
   Returns `{:ok, handle}` on success.
   """

--- a/lib/gpio/cdev.ex
+++ b/lib/gpio/cdev.ex
@@ -119,10 +119,12 @@ defmodule Circuits.GPIO.CDev do
   def open(gpio_spec, direction, options) do
     value = Keyword.fetch!(options, :initial_value)
     pull_mode = Keyword.fetch!(options, :pull_mode)
+    drive_mode = Keyword.fetch!(options, :drive_mode)
 
     with {:ok, location} <- find_location(gpio_spec, options),
          resolved_location = resolve_gpiochip(location),
-         {:ok, ref} <- Nif.open(gpio_spec, resolved_location, direction, value, pull_mode) do
+         {:ok, ref} <-
+           Nif.open(gpio_spec, resolved_location, direction, value, pull_mode, drive_mode) do
       {:ok, %__MODULE__{ref: ref}}
     end
   end
@@ -151,6 +153,11 @@ defmodule Circuits.GPIO.CDev do
     @impl Handle
     def set_pull_mode(%Circuits.GPIO.CDev{ref: ref}, pull_mode) do
       Nif.set_pull_mode(ref, pull_mode)
+    end
+
+    @impl Handle
+    def set_drive_mode(%Circuits.GPIO.CDev{ref: ref}, drive_mode) do
+      Nif.set_drive_mode(ref, drive_mode)
     end
 
     @impl Handle

--- a/lib/gpio/gpio_nif.ex
+++ b/lib/gpio/gpio_nif.ex
@@ -15,7 +15,7 @@ defmodule Circuits.GPIO.Nif do
     :erlang.load_nif(:code.priv_dir(:circuits_gpio) ++ ~c"/gpio_nif", 0)
   end
 
-  def open(_gpio_spec, _resolved_gpio_spec, _direction, _initial_value, _pull_mode),
+  def open(_gpio_spec, _resolved_gpio_spec, _direction, _initial_value, _pull_mode, _drive_mode),
     do: :erlang.nif_error(:nif_not_loaded)
 
   def close(_gpio), do: :erlang.nif_error(:nif_not_loaded)
@@ -27,6 +27,7 @@ defmodule Circuits.GPIO.Nif do
 
   def set_direction(_gpio, _direction), do: :erlang.nif_error(:nif_not_loaded)
   def set_pull_mode(_gpio, _pull_mode), do: :erlang.nif_error(:nif_not_loaded)
+  def set_drive_mode(_gpio, _drive_mode), do: :erlang.nif_error(:nif_not_loaded)
   def info(_gpio), do: :erlang.nif_error(:nif_not_loaded)
   def status(_resolved_gpio_spec), do: :erlang.nif_error(:nif_not_loaded)
   def backend_info(), do: :erlang.nif_error(:nif_not_loaded)

--- a/lib/gpio/handle.ex
+++ b/lib/gpio/handle.ex
@@ -31,6 +31,11 @@ defprotocol Circuits.GPIO.Handle do
   @spec set_pull_mode(t(), GPIO.pull_mode()) :: :ok | {:error, atom()}
   def set_pull_mode(handle, mode)
 
+  # Set the drive mode
+  @doc false
+  @spec set_drive_mode(t(), GPIO.drive_mode()) :: :ok | {:error, atom()}
+  def set_drive_mode(handle, mode)
+
   # Free up resources associated with the handle
   #
   # Well behaved backends free up their resources with the help of the Erlang

--- a/test/circuits_gpio_test.exs
+++ b/test/circuits_gpio_test.exs
@@ -91,7 +91,7 @@ defmodule Circuits.GPIOTest do
 
   describe "status/2" do
     test "all gpio_spec examples" do
-      expected = %{consumer: "", direction: :input, pull_mode: :none}
+      expected = %{consumer: "", direction: :input, pull_mode: :none, drive_mode: :push_pull}
 
       assert GPIO.status(5) == {:ok, expected}
       assert GPIO.status("pair_2_1") == {:ok, expected}
@@ -117,7 +117,8 @@ defmodule Circuits.GPIOTest do
                 %{
                   consumer: "stub",
                   direction: :output,
-                  pull_mode: :none
+                  pull_mode: :none,
+                  drive_mode: :push_pull
                 }}
 
       GPIO.close(gpio)
@@ -131,10 +132,84 @@ defmodule Circuits.GPIOTest do
                 %{
                   consumer: "stub",
                   direction: :input,
-                  pull_mode: :pullup
+                  pull_mode: :pullup,
+                  drive_mode: :push_pull
                 }}
 
       GPIO.close(gpio)
+    end
+  end
+
+  describe "drive_mode" do
+    test "can set drive mode in open" do
+      {:ok, gpio} = GPIO.open({@gpiochip, 0}, :output, drive_mode: :open_drain)
+
+      assert GPIO.status({@gpiochip, 0}) ==
+               {:ok,
+                %{
+                  consumer: "stub",
+                  direction: :output,
+                  pull_mode: :none,
+                  drive_mode: :open_drain
+                }}
+
+      GPIO.close(gpio)
+    end
+
+    test "can change drive mode after open" do
+      {:ok, gpio} = GPIO.open({@gpiochip, 0}, :output)
+      assert {:ok, %{drive_mode: :push_pull}} = GPIO.status({@gpiochip, 0})
+
+      :ok = GPIO.set_drive_mode(gpio, :open_source)
+      assert {:ok, %{drive_mode: :open_source}} = GPIO.status({@gpiochip, 0})
+
+      GPIO.close(gpio)
+    end
+
+    test "emulates open-drain in stub" do
+      # Pin 0 (output) connected to Pin 1 (input)
+      {:ok, out} = GPIO.open({@gpiochip, 0}, :output, drive_mode: :open_drain)
+      {:ok, p1} = GPIO.open({@gpiochip, 1}, :input, pull_mode: :pullup)
+
+      # 0 pulls line low
+      :ok = GPIO.write(out, 0)
+      assert GPIO.read(p1) == 0
+
+      # 1 floats, pullup makes it high
+      :ok = GPIO.write(out, 1)
+      assert GPIO.read(p1) == 1
+
+      # Turning off pullup causes it to float to 0
+      :ok = GPIO.set_pull_mode(p1, :none)
+      assert GPIO.read(p1) == 0
+
+      GPIO.close(out)
+      GPIO.close(p1)
+    end
+
+    test "emulates open-source in stub" do
+      # Pin 0 (output) connected to Pin 1 (input)
+      {:ok, out} = GPIO.open({@gpiochip, 0}, :output, drive_mode: :open_source)
+      {:ok, p1} = GPIO.open({@gpiochip, 1}, :input, pull_mode: :pulldown)
+
+      # 1 pulls line high
+      :ok = GPIO.write(out, 1)
+      assert GPIO.read(p1) == 1
+
+      # 0 floats, pulldown makes it low
+      :ok = GPIO.write(out, 0)
+      assert GPIO.read(p1) == 0
+
+      # Turning off pulldown causes it to float to 0
+      :ok = GPIO.set_pull_mode(p1, :none)
+      assert GPIO.read(p1) == 0
+
+      GPIO.close(out)
+      GPIO.close(p1)
+    end
+
+    test "raises ArgumentError for invalid drive modes" do
+      assert_raise ArgumentError, fn -> GPIO.open({@gpiochip, 0}, :output, drive_mode: :bogus) end
     end
   end
 


### PR DESCRIPTION
As the title says - adds support for open drain and open source modes for GPIO. Marking as draft because although it compiles, and the updated tests pass, I haven't tested this on hardware.

I tried to mirror the existing structure for the `:pull_mode`.

My understanding is that pretty much every modern CPU supports open drain mode? But there might be some older ones that don't? If you have any suggestions on if that's a concern/how to detect it so we can raise an error, I'd be happy to hear them 🙂 

