### PR TITLE
Fix memory leak on interrupt notifications

### DIFF
--- a/c_src/gpio_nif.c
+++ b/c_src/gpio_nif.c
@@ -85,18 +85,27 @@ static ErlNifResourceTypeInit gpio_pin_init = {gpio_pin_dtor, gpio_pin_stop, gpi
 #endif
 
 int send_gpio_message(ErlNifEnv *env,
+                      ErlNifEnv *msg_env,
                       ERL_NIF_TERM gpio_spec,
                       ErlNifPid *pid,
                       int64_t timestamp,
                       int value)
 {
-    ERL_NIF_TERM msg = enif_make_tuple4(env,
+    // gpio_spec lives in the pin's environment, so it has to be copied to
+    // msg_env before it can be used in a term created there.
+    ERL_NIF_TERM msg = enif_make_tuple4(msg_env,
                                         atom_circuits_gpio,
-                                        gpio_spec,
-                                        enif_make_int64(env, timestamp),
-                                        enif_make_int(env, value));
+                                        enif_make_copy(msg_env, gpio_spec),
+                                        enif_make_int64(msg_env, timestamp),
+                                        enif_make_int(msg_env, value));
 
-    return enif_send(env, pid, NULL, msg);
+    int rc = enif_send(env, pid, msg_env, msg);
+
+    // Clear msg_env so that it can be reused. Not clearing it would leak the
+    // message terms until the environment is freed.
+    enif_clear_env(msg_env);
+
+    return rc;
 }
 
 static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM info)

--- a/c_src/gpio_nif.h
+++ b/c_src/gpio_nif.h
@@ -218,7 +218,22 @@ ERL_NIF_TERM make_errno_error(ErlNifEnv *env, int errno_value);
 ERL_NIF_TERM make_string_binary(ErlNifEnv *env, const char *str);
 int enif_get_boolean(ErlNifEnv *env, ERL_NIF_TERM term, bool *v);
 
+/**
+ * Send a GPIO interrupt message to a process
+ *
+ * @param env the caller's environment: the process bound environment when
+ *            called from a NIF or NULL when called from a custom thread
+ * @param msg_env a process independent environment for building the message.
+ *                It is cleared before this function returns so that it can be
+ *                reused.
+ * @param gpio_spec the GPIO spec term (may be from another environment)
+ * @param pid who to notify
+ * @param timestamp event timestamp in nanoseconds
+ * @param value the new GPIO value
+ * @return true on success (see enif_send)
+ */
 int send_gpio_message(ErlNifEnv *env,
+                      ErlNifEnv *msg_env,
                       ERL_NIF_TERM gpio_spec,
                       ErlNifPid *pid,
                       int64_t timestamp,

--- a/c_src/hal_cdev_gpio_interrupts.c
+++ b/c_src/hal_cdev_gpio_interrupts.c
@@ -54,7 +54,7 @@ static void compact_listeners(struct gpio_monitor_info *infos)
     memset(&infos[write_pos], 0, remaining * sizeof(struct gpio_monitor_info));
 }
 
-static int handle_gpio_update(ErlNifEnv *env,
+static int handle_gpio_update(ErlNifEnv *msg_env,
                               struct gpio_monitor_info *info,
                               uint64_t timestamp,
                               int event_id)
@@ -63,13 +63,13 @@ static int handle_gpio_update(ErlNifEnv *env,
     int value = event_id == GPIO_V2_LINE_EVENT_RISING_EDGE ? 1 : 0;
 
     // Convert true/false return to the typical 0/negative returns of this file
-    if (send_gpio_message(env, info->gpio_spec, &info->pid, timestamp, value))
+    if (send_gpio_message(NULL, msg_env, info->gpio_spec, &info->pid, timestamp, value))
         return 0;
     else
         return -1;
 }
 
-static int process_gpio_events(ErlNifEnv *env,
+static int process_gpio_events(ErlNifEnv *msg_env,
                                struct gpio_monitor_info *info)
 {
     struct gpio_v2_line_event events[16];
@@ -81,7 +81,7 @@ static int process_gpio_events(ErlNifEnv *env,
 
     int num_events = amount_read / sizeof(struct gpio_v2_line_event);
     for (int i = 0; i < num_events; i++) {
-        if (handle_gpio_update(env,
+        if (handle_gpio_update(msg_env,
                                info,
                                events[i].timestamp_ns,
                                events[i].id) < 0) {
@@ -92,7 +92,7 @@ static int process_gpio_events(ErlNifEnv *env,
     return 0;
 }
 
-static void add_listener(ErlNifEnv *env, struct gpio_monitor_info *infos, const struct gpio_monitor_info *to_add)
+static void add_listener(struct gpio_monitor_info *infos, const struct gpio_monitor_info *to_add)
 {
     for (int i = 0; i < MAX_GPIO_LISTENERS; i++) {
         if (infos[i].trigger == TRIGGER_NONE || infos[i].fd == to_add->fd) {
@@ -124,7 +124,9 @@ void *gpio_poller_thread(void *arg)
     int *pipefd = arg;
     debug("gpio_poller_thread started");
 
-    ErlNifEnv *env = enif_alloc_env();
+    // Environment for building messages. It's cleared after each send so it
+    // can be allocated once and reused for the life of the thread.
+    ErlNifEnv *msg_env = enif_alloc_env();
 
     init_listeners(monitor_info);
     for (;;) {
@@ -169,7 +171,7 @@ void *gpio_poller_thread(void *arg)
         for (nfds_t i = 0; i < count - 1; i++) {
             short gpio_revents = fdset[i].revents;
             if (gpio_revents & POLLIN) {
-                if (process_gpio_events(env, &monitor_info[i]) < 0) {
+                if (process_gpio_events(msg_env, &monitor_info[i]) < 0) {
                     error("error processing gpio events for %d", monitor_info[i].offset);
                     monitor_info[i].trigger = TRIGGER_NONE;
                     cleanup = true;
@@ -190,7 +192,7 @@ void *gpio_poller_thread(void *arg)
             }
 
             if (message.trigger != TRIGGER_NONE)
-                add_listener(env, monitor_info, &message);
+                add_listener(monitor_info, &message);
             else
                 remove_listener(monitor_info, message.fd);
         }
@@ -200,7 +202,7 @@ void *gpio_poller_thread(void *arg)
             compact_listeners(monitor_info);
     }
 
-    enif_free_env(env);
+    enif_free_env(msg_env);
     debug("gpio_poller_thread ended");
     return NULL;
 }

--- a/c_src/hal_stub.c
+++ b/c_src/hal_stub.c
@@ -163,7 +163,9 @@ static void maybe_send_notification(ErlNifEnv *env, struct gpio_pin *pin, int va
 
     if (send_it) {
         ErlNifTime now = enif_monotonic_time(ERL_NIF_NSEC);
-        send_gpio_message(env, pin->gpio_spec, &stub_priv->pid[pin->fd], now, value);
+        ErlNifEnv *msg_env = enif_alloc_env();
+        send_gpio_message(env, msg_env, pin->gpio_spec, &stub_priv->pid[pin->fd], now, value);
+        enif_free_env(msg_env);
     }
 }
 


### PR DESCRIPTION
It turns out that the message environment when calling enif_send needs
to be cleared. This was found by Claude and is easily confirmed by
watching `:erlang.memory(:total)` whie processing a lot of interrupts.
