### PR TITLE
Remove Circuits.GPIO v1 set_interrupts initial message

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,6 @@ iex> flush
 :ok
 ```
 
-Note that after calling `set_interrupts`, the calling process will receive an
-initial message with the state of the pin. This prevents the race condition
-between getting the initial state of the pin and turning on interrupts. Without
-it, you could get the state of the pin, it could change states, and then you
-could start waiting on it for interrupts. If that happened, you would be out of
-sync.
-
 ### Internal pull-up/pull-down
 
 To connect or disconnect an internal [pull-up or pull-down resistor](https://github.com/raspberrypilearning/physical-computing-guide/blob/master/pull_up_down.md) to a GPIO

--- a/notebooks/basics.livemd
+++ b/notebooks/basics.livemd
@@ -217,13 +217,6 @@ IEx.Helpers.flush()
 :ok
 ```
 
-Note that after calling `set_interrupts`, the calling process will receive an
-initial message with the state of the pin. This prevents the race condition
-between getting the initial state of the pin and turning on interrupts. Without
-it, you could get the state of the pin, it could change states, and then you
-could start waiting on it for interrupts. If that happened, you would be out of
-sync.
-
 ### Internal pull-up/pull-down
 
 To connect or disconnect an internal [pull-up or pull-down resistor](https://github.com/raspberrypilearning/physical-computing-guide/blob/master/pull_up_down.md) to a GPIO


### PR DESCRIPTION
The initial message was removed from v2 and documented as removed in the
v1 to v2 upgrade instructions. These docs should have been removed then.

The standard pattern of subscribing to changes first and then getting
the current value to avoid missing an initial state change.
