### PR TITLE
Add subscribe/2 as an alternative to set_interrupts/3

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,18 +113,21 @@ iex> Circuits.GPIO.read(gpio)
 ```
 
 If you'd like to get a message when the button is pressed or released, call the
-`set_interrupts` function. You can trigger on the `:rising` edge, `:falling`
-edge or `:both`.
+`subscribe/2` function.
 
 ```elixir
-iex> Circuits.GPIO.set_interrupts(gpio, :both)
-:ok
+iex> Circuits.GPIO.subscribe(gpio)
+{:ok, ref}
 
 iex> flush
-{:circuits_gpio, "GPIO17", 1233456, 1}
-{:circuits_gpio, "GPIO17", 1234567, 0}
+{:circuits_gpio, %{ref: ref, timestamp: 1233456, value: 1, previous_value: 0}}
+{:circuits_gpio, %{ref: ref, timestamp: 1233457, value: 0, previous_value: 1}}
 :ok
 ```
+
+You may see existing code use `set_interrupts/3`. It's similar, but sends a
+`{:circuits_gpio, gpio_spec, timestamp, value}` tuple. New code should use
+`subscribe/2`.
 
 ### Internal pull-up/pull-down
 

--- a/c_src/gpio_nif.c
+++ b/c_src/gpio_nif.c
@@ -24,6 +24,10 @@ ERL_NIF_TERM atom_location;
 ERL_NIF_TERM atom_controller;
 ERL_NIF_TERM atom_circuits_gpio;
 ERL_NIF_TERM atom_consumer;
+ERL_NIF_TERM atom_ref;
+ERL_NIF_TERM atom_timestamp;
+ERL_NIF_TERM atom_value;
+ERL_NIF_TERM atom_previous_value;
 
 #ifdef DEBUG
 FILE *log_location = NULL;
@@ -39,6 +43,16 @@ static void release_gpio_pin(struct gpio_priv *priv, struct gpio_pin *pin)
         hal_close_gpio(pin);
         pin->fd = -1;
     }
+}
+
+static void set_pin_terms(struct gpio_pin *pin,
+                          ERL_NIF_TERM gpio_spec,
+                          bool notify_map,
+                          ERL_NIF_TERM notify_id)
+{
+    enif_clear_env(pin->env);
+    pin->gpio_spec = enif_make_copy(pin->env, gpio_spec);
+    pin->notify_id = notify_map ? enif_make_copy(pin->env, notify_id) : 0;
 }
 
 static void gpio_pin_dtor(ErlNifEnv *env, void *obj)
@@ -108,6 +122,31 @@ int send_gpio_message(ErlNifEnv *env,
     return rc;
 }
 
+int send_gpio_change(ErlNifEnv *env,
+                     ErlNifEnv *msg_env,
+                     ERL_NIF_TERM notify_id,
+                     ErlNifPid *pid,
+                     int64_t timestamp,
+                     uint64_t value,
+                     uint64_t previous_value)
+{
+    // notify_id lives in the pin's environment, so it has to be copied to
+    // msg_env before it can be used in a term created there.
+    ERL_NIF_TERM map = enif_make_new_map(msg_env);
+    enif_make_map_put(msg_env, map, atom_ref, enif_make_copy(msg_env, notify_id), &map);
+    enif_make_map_put(msg_env, map, atom_timestamp, enif_make_int64(msg_env, timestamp), &map);
+    enif_make_map_put(msg_env, map, atom_value, enif_make_uint64(msg_env, value), &map);
+    enif_make_map_put(msg_env, map, atom_previous_value, enif_make_uint64(msg_env, previous_value), &map);
+
+    ERL_NIF_TERM msg = enif_make_tuple2(msg_env, atom_circuits_gpio, map);
+
+    int rc = enif_send(env, pid, msg_env, msg);
+
+    enif_clear_env(msg_env);
+
+    return rc;
+}
+
 static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM info)
 {
     (void) info;
@@ -126,6 +165,10 @@ static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM info)
     atom_controller = enif_make_atom(env, "controller");
     atom_circuits_gpio = enif_make_atom(env, "circuits_gpio");
     atom_consumer = enif_make_atom(env, "consumer");
+    atom_ref = enif_make_atom(env, "ref");
+    atom_timestamp = enif_make_atom(env, "timestamp");
+    atom_value = enif_make_atom(env, "value");
+    atom_previous_value = enif_make_atom(env, "previous_value");
 
     size_t extra_size = hal_priv_size();
     struct gpio_priv *priv = enif_alloc(sizeof(struct gpio_priv) + extra_size);
@@ -297,6 +340,7 @@ static ERL_NIF_TERM set_interrupts(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
         pin->config = old_config;
         return enif_make_badarg(env);
     }
+    pin->notify_map = false;
 
     int rc = hal_apply_interrupts(pin, env);
     if (rc < 0) {
@@ -304,6 +348,64 @@ static ERL_NIF_TERM set_interrupts(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
         return make_errno_error(env, rc);
     }
 
+    return atom_ok;
+}
+
+static ERL_NIF_TERM subscribe(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    struct gpio_priv *priv = enif_priv_data(env);
+    struct gpio_pin *pin;
+
+    // subscribe(resource, notify_id, trigger, pid)
+    if (argc != 4 ||
+            !enif_get_resource(env, argv[0], priv->gpio_pin_rt, (void**) &pin))
+        return enif_make_badarg(env);
+
+    struct gpio_config old_config = pin->config;
+    bool old_notify_map = pin->notify_map;
+    ERL_NIF_TERM old_gpio_spec = enif_make_copy(env, pin->gpio_spec);
+    ERL_NIF_TERM old_notify_id = old_notify_map ? enif_make_copy(env, pin->notify_id) : 0;
+    if (!get_trigger(env, argv[2], &pin->config.trigger) ||
+            !enif_get_local_pid(env, argv[3], &pin->config.pid)) {
+        pin->config = old_config;
+        return enif_make_badarg(env);
+    }
+
+    // A single line's previous_value is always the opposite of the new value
+    // (an edge toggles it), so no value needs to be sampled here.
+    pin->notify_map = true;
+    set_pin_terms(pin, old_gpio_spec, true, argv[1]);
+
+    int rc = hal_apply_interrupts(pin, env);
+    if (rc < 0) {
+        pin->config = old_config;
+        pin->notify_map = old_notify_map;
+        set_pin_terms(pin, old_gpio_spec, old_notify_map, old_notify_id);
+        return make_errno_error(env, rc);
+    }
+
+    return atom_ok;
+}
+
+static ERL_NIF_TERM unsubscribe(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    struct gpio_priv *priv = enif_priv_data(env);
+    struct gpio_pin *pin;
+
+    if (argc != 1 ||
+            !enif_get_resource(env, argv[0], priv->gpio_pin_rt, (void**) &pin))
+        return enif_make_badarg(env);
+
+    struct gpio_config old_config = pin->config;
+    pin->config.trigger = TRIGGER_NONE;
+
+    int rc = hal_apply_interrupts(pin, env);
+    if (rc < 0) {
+        pin->config = old_config;
+        return make_errno_error(env, rc);
+    }
+
+    pin->notify_map = false;
     return atom_ok;
 }
 
@@ -416,6 +518,8 @@ static ERL_NIF_TERM open_gpio(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     pin->offset = offset;
     pin->env = enif_alloc_env();
     pin->gpio_spec = enif_make_copy(pin->env, argv[0]);
+    pin->notify_id = 0;
+    pin->notify_map = false;
     pin->hal_priv = priv->hal_priv;
     pin->config.is_output = is_output;
     pin->config.trigger = TRIGGER_NONE;
@@ -477,6 +581,8 @@ static ErlNifFunc nif_funcs[] = {
     {"read", 1, read_gpio, 0},
     {"write", 2, write_gpio, 0},
     {"set_interrupts", 4, set_interrupts, 0},
+    {"subscribe", 4, subscribe, 0},
+    {"unsubscribe", 1, unsubscribe, 0},
     {"set_direction", 2, set_direction, 0},
     {"set_pull_mode", 2, set_pull_mode, 0},
     {"set_drive_mode", 2, set_drive_mode, 0},

--- a/c_src/gpio_nif.h
+++ b/c_src/gpio_nif.h
@@ -77,7 +77,15 @@ struct gpio_pin {
 
     // NIF environment for holding on to the gpio_spec term
     ErlNifEnv *env;
+
+    // Used by set_interrupts/3 notifications ({:circuits_gpio, spec, ...})
     ERL_NIF_TERM gpio_spec;
+
+    // Used by subscribe/2 notifications ({:circuits_gpio, %{ref: ..., ...}}).
+    ERL_NIF_TERM notify_id;
+
+    // true to use subscribe/2 notification format
+    bool notify_map;
 };
 
 // Atoms
@@ -89,6 +97,10 @@ extern ERL_NIF_TERM atom_location;
 extern ERL_NIF_TERM atom_controller;
 extern ERL_NIF_TERM atom_circuits_gpio;
 extern ERL_NIF_TERM atom_consumer;
+extern ERL_NIF_TERM atom_ref;
+extern ERL_NIF_TERM atom_timestamp;
+extern ERL_NIF_TERM atom_value;
+extern ERL_NIF_TERM atom_previous_value;
 
 // HAL
 
@@ -239,4 +251,29 @@ int send_gpio_message(ErlNifEnv *env,
                       int64_t timestamp,
                       int value);
 
+/**
+ * Send a GPIO change notification (subscribe/2 map format) to a process
+ *
+ * Builds {:circuits_gpio, %{ref: notify_id, timestamp: ts, value: value,
+ * previous_value: previous_value}}.
+ *
+ * @param env the caller's environment: the process bound environment when
+ *            called from a NIF or NULL when called from a custom thread
+ * @param msg_env a process independent environment for building the message.
+ *                It is cleared before this function returns so that it can be
+ *                reused.
+ * @param notify_id the ref/tag term to echo (may be from another environment)
+ * @param pid who to notify
+ * @param timestamp event timestamp in nanoseconds
+ * @param value the new group value bitmap
+ * @param previous_value the group value bitmap before this change
+ * @return true on success (see enif_send)
+ */
+int send_gpio_change(ErlNifEnv *env,
+                     ErlNifEnv *msg_env,
+                     ERL_NIF_TERM notify_id,
+                     ErlNifPid *pid,
+                     int64_t timestamp,
+                     uint64_t value,
+                     uint64_t previous_value);
 #endif // GPIO_NIF_H

--- a/c_src/hal_cdev_gpio_interrupts.c
+++ b/c_src/hal_cdev_gpio_interrupts.c
@@ -29,13 +29,26 @@ struct gpio_monitor_info {
     enum trigger_mode trigger;
     int fd;
     int offset;
+    bool notify_map;
+    ErlNifEnv *env;
     ErlNifPid pid;
     ERL_NIF_TERM gpio_spec;
+    ERL_NIF_TERM notify_id;
 };
 
 static void init_listeners(struct gpio_monitor_info *infos)
 {
     memset(infos, 0, MAX_GPIO_LISTENERS * sizeof(struct gpio_monitor_info));
+}
+
+static void clear_listener(struct gpio_monitor_info *info)
+{
+    if (info->env) {
+        enif_free_env(info->env);
+        info->env = NULL;
+    }
+
+    memset(info, 0, sizeof(struct gpio_monitor_info));
 }
 
 static void compact_listeners(struct gpio_monitor_info *infos)
@@ -63,10 +76,14 @@ static int handle_gpio_update(ErlNifEnv *msg_env,
     int value = event_id == GPIO_V2_LINE_EVENT_RISING_EDGE ? 1 : 0;
 
     // Convert true/false return to the typical 0/negative returns of this file
-    if (send_gpio_message(NULL, msg_env, info->gpio_spec, &info->pid, timestamp, value))
-        return 0;
+    int rc;
+    if (info->notify_map)
+        // A single line's previous value is the opposite of the new value.
+        rc = send_gpio_change(NULL, msg_env, info->notify_id, &info->pid, timestamp, value, value ^ 1);
     else
-        return -1;
+        rc = send_gpio_message(NULL, msg_env, info->gpio_spec, &info->pid, timestamp, value);
+
+    return rc ? 0 : -1;
 }
 
 static int process_gpio_events(ErlNifEnv *msg_env,
@@ -94,13 +111,21 @@ static int process_gpio_events(ErlNifEnv *msg_env,
 
 static void add_listener(struct gpio_monitor_info *infos, const struct gpio_monitor_info *to_add)
 {
+    // The message owns its term environment (see update_polling_thread). Taking
+    // the message by value transfers that ownership to the listener slot, so the
+    // poller never dereferences the pin's environment.
     for (int i = 0; i < MAX_GPIO_LISTENERS; i++) {
         if (infos[i].trigger == TRIGGER_NONE || infos[i].fd == to_add->fd) {
-            memcpy(&infos[i], to_add, sizeof(struct gpio_monitor_info));
+            clear_listener(&infos[i]);
+            infos[i] = *to_add;
             return;
         }
     }
     error("Too many gpio listeners. Max is %d", MAX_GPIO_LISTENERS);
+
+    // No slot available, so free the environment that would have been adopted.
+    if (to_add->env)
+        enif_free_env(to_add->env);
 }
 
 static void remove_listener(struct gpio_monitor_info *infos, int fd)
@@ -109,7 +134,7 @@ static void remove_listener(struct gpio_monitor_info *infos, int fd)
     bool cleanup = false;
     for (int i = 0; i < MAX_GPIO_LISTENERS; i++) {
         if (infos[i].fd == fd) {
-            infos[i].trigger = TRIGGER_NONE;
+            clear_listener(&infos[i]);
             cleanup = true;
         }
     }
@@ -173,12 +198,12 @@ void *gpio_poller_thread(void *arg)
             if (gpio_revents & POLLIN) {
                 if (process_gpio_events(msg_env, &monitor_info[i]) < 0) {
                     error("error processing gpio events for %d", monitor_info[i].offset);
-                    monitor_info[i].trigger = TRIGGER_NONE;
+                    clear_listener(&monitor_info[i]);
                     cleanup = true;
                 }
             } else if (gpio_revents & (POLLERR | POLLHUP | POLLNVAL)) {
                 error("error listening on gpio %d", monitor_info[i].offset);
-                monitor_info[i].trigger = TRIGGER_NONE;
+                clear_listener(&monitor_info[i]);
                 cleanup = true;
             }
         }
@@ -202,6 +227,9 @@ void *gpio_poller_thread(void *arg)
             compact_listeners(monitor_info);
     }
 
+    for (int i = 0; i < MAX_GPIO_LISTENERS; i++)
+        clear_listener(&monitor_info[i]);
+
     enif_free_env(msg_env);
     debug("gpio_poller_thread ended");
     return NULL;
@@ -212,13 +240,29 @@ int update_polling_thread(struct gpio_pin *pin)
     struct hal_cdev_gpio_priv *priv = (struct hal_cdev_gpio_priv *) pin->hal_priv;
 
     struct gpio_monitor_info message;
+    memset(&message, 0, sizeof(message));
     message.trigger = pin->config.trigger;
     message.fd = pin->fd;
     message.offset = pin->offset;
-    message.gpio_spec = pin->gpio_spec;
+    message.notify_map = pin->notify_map;
     message.pid = pin->config.pid;
+
+    // For an active subscription, copy the term the poller will echo into an
+    // environment owned by the message. This happens on the caller's thread
+    // while pin->env is valid, so the poller never has to dereference pin->env
+    // (which this thread may clear on re-subscribe or free on close).
+    if (pin->config.trigger != TRIGGER_NONE) {
+        message.env = enif_alloc_env();
+        if (pin->notify_map)
+            message.notify_id = enif_make_copy(message.env, pin->notify_id);
+        else
+            message.gpio_spec = enif_make_copy(message.env, pin->gpio_spec);
+    }
+
     if (write(priv->pipe_fds[1], &message, sizeof(message)) != sizeof(message)) {
         error("Error writing polling thread!");
+        if (message.env)
+            enif_free_env(message.env);
         return -1;
     }
     return 0;

--- a/c_src/hal_stub.c
+++ b/c_src/hal_stub.c
@@ -164,7 +164,13 @@ static void maybe_send_notification(ErlNifEnv *env, struct gpio_pin *pin, int va
     if (send_it) {
         ErlNifTime now = enif_monotonic_time(ERL_NIF_NSEC);
         ErlNifEnv *msg_env = enif_alloc_env();
-        send_gpio_message(env, msg_env, pin->gpio_spec, &stub_priv->pid[pin->fd], now, value);
+        if (pin->notify_map) {
+            // A single line's previous value is the opposite of the new value.
+            uint64_t v = value > 0 ? 1 : 0;
+            send_gpio_change(env, msg_env, pin->notify_id, &stub_priv->pid[pin->fd], now, v, v ^ 1);
+        } else {
+            send_gpio_message(env, msg_env, pin->gpio_spec, &stub_priv->pid[pin->fd], now, value);
+        }
         enif_free_env(msg_env);
     }
 }

--- a/lib/gpio.ex
+++ b/lib/gpio.ex
@@ -181,6 +181,19 @@ defmodule Circuits.GPIO do
   """
   @type interrupt_options() :: [suppress_glitches: boolean(), receiver: pid() | atom()]
 
+  @typedoc """
+  Options for `subscribe/2`
+
+  * `:receiver` - process that should receive notifications. Defaults to the
+    calling process (`self()`).
+  * `:tag` - a term echoed in the `:ref` field of every notification instead of
+    the auto-generated reference. Use this to route messages with a
+    domain-specific label.
+  * `:trigger` - notify on `:rising` edges, `:falling` edges, or `:both`.
+    Defaults to `:both`.
+  """
+  @type subscribe_options() :: [trigger: trigger(), receiver: pid() | atom(), tag: term()]
+
   @doc """
   Guard version of `gpio_spec?/1`
 
@@ -380,6 +393,10 @@ defmodule Circuits.GPIO do
   @doc """
   Enable or disable GPIO value change notifications
 
+  New code should prefer `subscribe/2`, which delivers a map (with the value and
+  previous value) and returns a reference for matching messages. `set_interrupts/3`
+  remains for backwards compatibility and sends the tuple described below.
+
   Notifications are sent based on the trigger:
 
   * `:none` - No notifications are sent
@@ -414,6 +431,51 @@ defmodule Circuits.GPIO do
   """
   @spec set_interrupts(Handle.t(), trigger(), interrupt_options()) :: :ok | {:error, atom()}
   defdelegate set_interrupts(handle, trigger, options \\ []), to: Handle
+
+  @doc """
+  Subscribe to GPIO value change notifications
+
+  This is the preferred way to receive change notifications. It returns
+  `{:ok, ref}` where `ref` is a reference echoed in every notification so you can
+  match messages to this subscription.
+
+  Available options:
+
+  * `:receiver` - process that should receive notifications. Defaults to the
+    calling process (`self()`).
+  * `:tag` - a term echoed in the `:ref` field instead of the auto-generated
+    reference.
+  * `:trigger` - send notifications on the `:rising`, `:falling`, or `:both`
+    edges. Defaults to `:both`.
+
+  Notification messages are maps:
+
+  ```
+  {:circuits_gpio, %{ref: ref, timestamp: timestamp, value: value, previous_value: previous_value}}
+  ```
+
+  Where `ref` is the reference returned by this function (or your `:tag`),
+  `timestamp` is an OS monotonic timestamp in nanoseconds, `value` is the new
+  value (`0` or `1`), and `previous_value` is the value just before the change.
+
+  Timestamps are not necessarily the same as from `System.monotonic_time/0`.
+  For example, with the cdev backend, they're applied by the Linux kernel or
+  can come from a hardware timer. Erlang's monotonic time is adjusted so
+  it's not the same as OS monotonic time. The result is that these timestamps
+  can be compared with each other, but not with anything else.
+
+  NOTE: You will need to keep the handle from `open/3` (for example, in your
+  `GenServer`'s state) so that it isn't garbage collected. Notifications stop
+  when it is collected.
+  """
+  @spec subscribe(Handle.t(), subscribe_options()) :: {:ok, term()} | {:error, atom()}
+  defdelegate subscribe(handle, options \\ []), to: Handle
+
+  @doc """
+  Stop GPIO value change notifications started with `subscribe/2`
+  """
+  @spec unsubscribe(Handle.t()) :: :ok | {:error, atom()}
+  defdelegate unsubscribe(handle), to: Handle
 
   @doc """
   Change the direction of the pin

--- a/lib/gpio/cdev.ex
+++ b/lib/gpio/cdev.ex
@@ -163,20 +163,36 @@ defmodule Circuits.GPIO.CDev do
     @impl Handle
     def set_interrupts(%Circuits.GPIO.CDev{ref: ref}, trigger, options) do
       suppress_glitches = Keyword.get(options, :suppress_glitches, true)
+      Nif.set_interrupts(ref, trigger, suppress_glitches, resolve_receiver(options))
+    end
 
-      receiver =
-        case Keyword.get(options, :receiver) do
-          pid when is_pid(pid) -> pid
-          name when is_atom(name) -> Process.whereis(name) || self()
-          _ -> self()
-        end
+    @impl Handle
+    def subscribe(%Circuits.GPIO.CDev{ref: ref}, options) do
+      notify_id = Keyword.get(options, :tag) || make_ref()
+      trigger = Keyword.get(options, :trigger) || :both
 
-      Nif.set_interrupts(ref, trigger, suppress_glitches, receiver)
+      case Nif.subscribe(ref, notify_id, trigger, resolve_receiver(options)) do
+        :ok -> {:ok, notify_id}
+        error -> error
+      end
+    end
+
+    @impl Handle
+    def unsubscribe(%Circuits.GPIO.CDev{ref: ref}) do
+      Nif.unsubscribe(ref)
     end
 
     @impl Handle
     def close(%Circuits.GPIO.CDev{ref: ref}) do
       Nif.close(ref)
+    end
+
+    defp resolve_receiver(options) do
+      case Keyword.get(options, :receiver) do
+        pid when is_pid(pid) -> pid
+        name when is_atom(name) and not is_nil(name) -> Process.whereis(name) || self()
+        _ -> self()
+      end
     end
   end
 end

--- a/lib/gpio/diagnostics.ex
+++ b/lib/gpio/diagnostics.ex
@@ -97,6 +97,7 @@ defmodule Circuits.GPIO.Diagnostics do
       {"Can set 0 on open", &check_setting_initial_value/3, value: 0},
       {"Can set 1 on open", &check_setting_initial_value/3, value: 1},
       {"Input interrupts sent", &check_interrupts/3, []},
+      {"Subscribe notifications sent", &check_subscribe/3, []},
       {"Interrupt timing sane", &check_interrupt_timing/3, []},
       {"Internal pullup works", &check_pullup/3, []},
       {"Internal pulldown works", &check_pulldown/3, []},
@@ -281,24 +282,54 @@ defmodule Circuits.GPIO.Diagnostics do
   end
 
   @doc false
+  @spec check_subscribe(GPIO.gpio_spec(), GPIO.gpio_spec(), keyword()) :: :ok
+  def check_subscribe(out_gpio_spec, in_gpio_spec, _options) do
+    {:ok, out_gpio} = GPIO.open(out_gpio_spec, :output, initial_value: 0)
+    {:ok, in_gpio} = GPIO.open(in_gpio_spec, :input)
+
+    {:ok, ref} = GPIO.subscribe(in_gpio)
+
+    # No initial notification
+    refute_receive {:circuits_gpio, _}
+
+    # Toggle enough times to avoid being tricked by something that
+    # works a few times and then stops.
+    for _ <- 1..64 do
+      GPIO.write(out_gpio, 1)
+      _ = assert_receive {:circuits_gpio, %{ref: ^ref, value: 1, previous_value: 0}}
+
+      GPIO.write(out_gpio, 0)
+      _ = assert_receive {:circuits_gpio, %{ref: ^ref, value: 0, previous_value: 1}}
+    end
+
+    # Unsubscribing stops notifications
+    :ok = GPIO.unsubscribe(in_gpio)
+    GPIO.write(out_gpio, 1)
+    refute_receive {:circuits_gpio, _}
+
+    GPIO.close(out_gpio)
+    GPIO.close(in_gpio)
+  end
+
+  @doc false
   @spec check_interrupt_timing(GPIO.gpio_spec(), GPIO.gpio_spec(), keyword()) :: :ok
   def check_interrupt_timing(out_gpio_spec, in_gpio_spec, _options) do
     {:ok, out_gpio} = GPIO.open(out_gpio_spec, :output, initial_value: 0)
     {:ok, in_gpio} = GPIO.open(in_gpio_spec, :input)
 
-    :ok = GPIO.set_interrupts(in_gpio, :both)
+    {:ok, ref} = GPIO.subscribe(in_gpio)
 
     # No notifications until something changes
-    refute_receive {:circuits_gpio, _, _, _}
+    refute_receive {:circuits_gpio, _}
 
     GPIO.write(out_gpio, 1)
-    {_, _, first_ns, _} = assert_receive {:circuits_gpio, ^in_gpio_spec, _, 1}
+    {_, %{timestamp: first_ns}} = assert_receive {:circuits_gpio, %{ref: ^ref, value: 1}}
 
     GPIO.write(out_gpio, 0)
-    {_, _, second_ns, _} = assert_receive {:circuits_gpio, ^in_gpio_spec, _, 0}
+    {_, %{timestamp: second_ns}} = assert_receive {:circuits_gpio, %{ref: ^ref, value: 0}}
 
     # No notifications after this
-    refute_receive {:circuits_gpio, _, _, _}
+    refute_receive {:circuits_gpio, _}
 
     GPIO.close(out_gpio)
     GPIO.close(in_gpio)

--- a/lib/gpio/gpio_nif.ex
+++ b/lib/gpio/gpio_nif.ex
@@ -25,6 +25,9 @@ defmodule Circuits.GPIO.Nif do
   def set_interrupts(_gpio, _trigger, _suppress_glitches, _process),
     do: :erlang.nif_error(:nif_not_loaded)
 
+  def subscribe(_gpio, _notify_id, _trigger, _process), do: :erlang.nif_error(:nif_not_loaded)
+  def unsubscribe(_gpio), do: :erlang.nif_error(:nif_not_loaded)
+
   def set_direction(_gpio, _direction), do: :erlang.nif_error(:nif_not_loaded)
   def set_pull_mode(_gpio, _pull_mode), do: :erlang.nif_error(:nif_not_loaded)
   def set_drive_mode(_gpio, _drive_mode), do: :erlang.nif_error(:nif_not_loaded)

--- a/lib/gpio/handle.ex
+++ b/lib/gpio/handle.ex
@@ -49,4 +49,14 @@ defprotocol Circuits.GPIO.Handle do
   @doc false
   @spec set_interrupts(t(), GPIO.trigger(), GPIO.interrupt_options()) :: :ok | {:error, atom()}
   def set_interrupts(handle, trigger, options)
+
+  # Subscribe to change notifications, returning the ref/tag that's included in messages
+  @doc false
+  @spec subscribe(t(), GPIO.subscribe_options()) :: {:ok, term()} | {:error, atom()}
+  def subscribe(handle, options)
+
+  # Stop change notifications started with subscribe/2
+  @doc false
+  @spec unsubscribe(t()) :: :ok | {:error, atom()}
+  def unsubscribe(handle)
 end

--- a/notebooks/basics.livemd
+++ b/notebooks/basics.livemd
@@ -202,20 +202,36 @@ Circuits.GPIO.read(gpio)
 ```
 
 If you'd like to get a message when the button is pressed or released, call the
-`set_interrupts` function. You can trigger on the `:rising` edge, `:falling`
-edge or `:both`.
+`subscribe` function. By default it notifies on `:both` edges; pass a
+`:trigger` option to only get `:rising` or `:falling` edges.
 
 ```elixir
-Circuits.GPIO.set_interrupts(gpio, :both)
+{:ok, ref} = Circuits.GPIO.subscribe(gpio)
+```
 
+<!-- livebook:{"output":true} -->
+
+```
+{:ok, #Reference<0.0.0.0>}
+```
+
+Now press and release the button a few times, then flush the messages:
+
+```elixir
 IEx.Helpers.flush()
 ```
 
 <!-- livebook:{"output":true} -->
 
 ```
+{:circuits_gpio, %{ref: ref, timestamp: 1233456, value: 1, previous_value: 0}}
+{:circuits_gpio, %{ref: ref, timestamp: 1233457, value: 0, previous_value: 1}}
 :ok
 ```
+
+You may see existing code use `set_interrupts`, which sends a
+`{:circuits_gpio, gpio_spec, timestamp, value}` tuple instead. New code should
+prefer `subscribe`.
 
 ### Internal pull-up/pull-down
 

--- a/test/circuits_gpio_test.exs
+++ b/test/circuits_gpio_test.exs
@@ -320,123 +320,279 @@ defmodule Circuits.GPIOTest do
     GPIO.close(gpio)
   end
 
-  test "no initial interrupt on set_interrupts" do
-    {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
-    {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
+  describe "set_interrupts/3" do
+    test "no initial interrupt on set_interrupts" do
+      {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
+      {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
 
-    :ok = GPIO.set_interrupts(gpio1, :both)
-    refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, _}
+      :ok = GPIO.set_interrupts(gpio1, :both)
+      refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, _}
 
-    GPIO.close(gpio0)
-    GPIO.close(gpio1)
-  end
+      GPIO.close(gpio0)
+      GPIO.close(gpio1)
+    end
 
-  test "interrupts on both edges" do
-    {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
-    {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
-
-    :ok = GPIO.set_interrupts(gpio1, :both)
-    refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, _}
-
-    :ok = GPIO.write(gpio0, 1)
-    assert_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 1}
-
-    :ok = GPIO.write(gpio0, 0)
-    assert_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 0}
-
-    GPIO.close(gpio0)
-    GPIO.close(gpio1)
-  end
-
-  test "interrupt with various specs" do
-    # Test that interrupts sent the original spec that they were opened with
-    for spec1 <- [33, "pair_16_1", {"stub1", "pair_16_1"}] do
-      {:ok, gpio0} = GPIO.open({"gpiochip1", 0}, :output)
-      {:ok, gpio1} = GPIO.open(spec1, :input)
+    test "interrupts on both edges" do
+      {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
+      {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
 
       :ok = GPIO.set_interrupts(gpio1, :both)
       refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, _}
 
       :ok = GPIO.write(gpio0, 1)
-      assert_receive {:circuits_gpio, ^spec1, _timestamp, 1}
+      assert_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 1}
 
       :ok = GPIO.write(gpio0, 0)
-      assert_receive {:circuits_gpio, ^spec1, _timestamp, 0}
+      assert_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 0}
 
       GPIO.close(gpio0)
       GPIO.close(gpio1)
     end
+
+    test "interrupt with various specs" do
+      # Test that interrupts sent the original spec that they were opened with
+      for spec1 <- [33, "pair_16_1", {"stub1", "pair_16_1"}] do
+        {:ok, gpio0} = GPIO.open({"gpiochip1", 0}, :output)
+        {:ok, gpio1} = GPIO.open(spec1, :input)
+
+        :ok = GPIO.set_interrupts(gpio1, :both)
+
+        :ok = GPIO.write(gpio0, 1)
+        assert_receive {:circuits_gpio, ^spec1, _timestamp, 1}
+
+        :ok = GPIO.write(gpio0, 0)
+        assert_receive {:circuits_gpio, ^spec1, _timestamp, 0}
+
+        refute_receive _
+        GPIO.close(gpio0)
+        GPIO.close(gpio1)
+      end
+    end
+
+    test "interrupts on falling edges" do
+      {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
+      {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
+
+      :ok = GPIO.set_interrupts(gpio1, :falling)
+      refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, _}
+
+      :ok = GPIO.write(gpio0, 1)
+      refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 1}
+
+      :ok = GPIO.write(gpio0, 0)
+      assert_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 0}
+
+      GPIO.close(gpio0)
+      GPIO.close(gpio1)
+    end
+
+    test "interrupts on rising edges" do
+      {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
+      {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
+
+      :ok = GPIO.set_interrupts(gpio1, :rising)
+      refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 0}
+
+      :ok = GPIO.write(gpio0, 1)
+      assert_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 1}
+
+      :ok = GPIO.write(gpio0, 0)
+      refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 0}
+
+      GPIO.close(gpio0)
+      GPIO.close(gpio1)
+    end
+
+    test "can disable interrupts" do
+      {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
+      {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
+
+      :ok = GPIO.set_interrupts(gpio1, :both)
+      refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, _}
+
+      :ok = GPIO.write(gpio0, 1)
+      assert_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 1}
+
+      :ok = GPIO.set_interrupts(gpio1, :none)
+      :ok = GPIO.write(gpio0, 0)
+      refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 0}
+
+      GPIO.close(gpio0)
+      GPIO.close(gpio1)
+    end
+
+    test "no interrupts after closing" do
+      {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
+      {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
+
+      :ok = GPIO.set_interrupts(gpio1, :both)
+      refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, _}
+
+      :ok = GPIO.write(gpio0, 1)
+      assert_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 1}
+
+      GPIO.close(gpio1)
+      Process.sleep(10)
+
+      :ok = GPIO.write(gpio0, 0)
+      refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 0}
+
+      GPIO.close(gpio0)
+    end
   end
 
-  test "interrupts on falling edges" do
-    {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
-    {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
+  describe "subscribe/2" do
+    test "no initial interrupt" do
+      {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
+      {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
 
-    :ok = GPIO.set_interrupts(gpio1, :falling)
-    refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, _}
+      {:ok, _ref} = GPIO.subscribe(gpio1)
+      refute_receive _
 
-    :ok = GPIO.write(gpio0, 1)
-    refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 1}
+      GPIO.close(gpio0)
+      GPIO.close(gpio1)
+    end
 
-    :ok = GPIO.write(gpio0, 0)
-    assert_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 0}
+    test "interrupts on both edges" do
+      {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
+      {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
 
-    GPIO.close(gpio0)
-    GPIO.close(gpio1)
-  end
+      {:ok, ref} = GPIO.subscribe(gpio1)
+      refute_receive _
 
-  test "interrupts on rising edges" do
-    {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
-    {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
+      :ok = GPIO.write(gpio0, 1)
+      assert_receive {:circuits_gpio, %{ref: ^ref, value: 1, previous_value: 0}}
 
-    :ok = GPIO.set_interrupts(gpio1, :rising)
-    refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 0}
+      :ok = GPIO.write(gpio0, 0)
+      assert_receive {:circuits_gpio, %{ref: ^ref, value: 0, previous_value: 1}}
 
-    :ok = GPIO.write(gpio0, 1)
-    assert_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 1}
+      refute_receive _
+      GPIO.close(gpio0)
+      GPIO.close(gpio1)
+    end
 
-    :ok = GPIO.write(gpio0, 0)
-    refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 0}
+    test "tag replaces the ref in notifications" do
+      {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
+      {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
 
-    GPIO.close(gpio0)
-    GPIO.close(gpio1)
-  end
+      {:ok, tag} = GPIO.subscribe(gpio1, tag: :button)
+      assert tag == :button
 
-  test "can disable interrupts" do
-    {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
-    {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
+      :ok = GPIO.write(gpio0, 1)
+      assert_receive {:circuits_gpio, %{ref: :button, value: 1, previous_value: 0}}
 
-    :ok = GPIO.set_interrupts(gpio1, :both)
-    refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, _}
+      GPIO.close(gpio0)
+      GPIO.close(gpio1)
+    end
 
-    :ok = GPIO.write(gpio0, 1)
-    assert_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 1}
+    test "notifications go to the :receiver process" do
+      {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
+      {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
 
-    :ok = GPIO.set_interrupts(gpio1, :none)
-    :ok = GPIO.write(gpio0, 0)
-    refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 0}
+      parent = self()
+      receiver = spawn_link(fn -> receive do: (msg -> send(parent, {:got, msg})) end)
 
-    GPIO.close(gpio0)
-    GPIO.close(gpio1)
-  end
+      {:ok, ref} = GPIO.subscribe(gpio1, receiver: receiver)
 
-  test "no interrupts after closing" do
-    {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
-    {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
+      :ok = GPIO.write(gpio0, 1)
+      assert_receive {:got, {:circuits_gpio, %{ref: ^ref, value: 1, previous_value: 0}}}
+      # The subscribing process itself gets nothing
+      refute_receive {:circuits_gpio, _}
 
-    :ok = GPIO.set_interrupts(gpio1, :both)
-    refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, _}
+      GPIO.close(gpio0)
+      GPIO.close(gpio1)
+    end
 
-    :ok = GPIO.write(gpio0, 1)
-    assert_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 1}
+    test "interrupt with various specs" do
+      # Test that interrupts sent the original spec that they were opened with
+      for spec1 <- [33, "pair_16_1", {"stub1", "pair_16_1"}] do
+        {:ok, gpio0} = GPIO.open({"gpiochip1", 0}, :output)
+        {:ok, gpio1} = GPIO.open(spec1, :input)
 
-    GPIO.close(gpio1)
-    Process.sleep(10)
+        {:ok, ref} = GPIO.subscribe(gpio1)
+        refute_receive _
 
-    :ok = GPIO.write(gpio0, 0)
-    refute_receive {:circuits_gpio, {@gpiochip, 1}, _timestamp, 0}
+        :ok = GPIO.write(gpio0, 1)
+        assert_receive {:circuits_gpio, %{ref: ^ref, value: 1, previous_value: 0}}
 
-    GPIO.close(gpio0)
+        :ok = GPIO.write(gpio0, 0)
+        assert_receive {:circuits_gpio, %{ref: ^ref, value: 0, previous_value: 1}}
+
+        GPIO.close(gpio0)
+        GPIO.close(gpio1)
+      end
+    end
+
+    test "interrupts on falling edges" do
+      {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
+      {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
+
+      {:ok, ref} = GPIO.subscribe(gpio1, trigger: :falling)
+      refute_receive _
+
+      :ok = GPIO.write(gpio0, 1)
+      refute_receive _
+
+      :ok = GPIO.write(gpio0, 0)
+      assert_receive {:circuits_gpio, %{ref: ^ref, value: 0, previous_value: 1}}
+
+      GPIO.close(gpio0)
+      GPIO.close(gpio1)
+    end
+
+    test "interrupts on rising edges" do
+      {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
+      {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
+
+      {:ok, ref} = GPIO.subscribe(gpio1, trigger: :rising)
+      refute_receive _
+
+      :ok = GPIO.write(gpio0, 1)
+      assert_receive {:circuits_gpio, %{ref: ^ref, value: 1, previous_value: 0}}
+
+      :ok = GPIO.write(gpio0, 0)
+      refute_receive _
+
+      GPIO.close(gpio0)
+      GPIO.close(gpio1)
+    end
+
+    test "can unsubscribe" do
+      {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
+      {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
+
+      {:ok, ref} = GPIO.subscribe(gpio1)
+      refute_receive _
+
+      :ok = GPIO.write(gpio0, 1)
+      assert_receive {:circuits_gpio, %{ref: ^ref, value: 1, previous_value: 0}}
+
+      :ok = GPIO.unsubscribe(gpio1)
+      :ok = GPIO.write(gpio0, 0)
+      refute_receive _
+
+      GPIO.close(gpio0)
+      GPIO.close(gpio1)
+    end
+
+    test "no messages after closing" do
+      {:ok, gpio0} = GPIO.open({@gpiochip, 0}, :output)
+      {:ok, gpio1} = GPIO.open({@gpiochip, 1}, :input)
+
+      {:ok, ref} = GPIO.subscribe(gpio1)
+      refute_receive _
+
+      :ok = GPIO.write(gpio0, 1)
+      assert_receive {:circuits_gpio, %{ref: ^ref, value: 1, previous_value: 0}}
+
+      GPIO.close(gpio1)
+      Process.sleep(10)
+
+      :ok = GPIO.write(gpio0, 0)
+      refute_receive _
+
+      GPIO.close(gpio0)
+    end
   end
 
   test "opening as an output with no initial_value defaults to 0" do


### PR DESCRIPTION
This adds a new way to watch for GPIO value changes that uses a map to
allow new fields to be added in the future. It also adds the concept of
a subscription reference which is easier and more idiomatic to match
against. Users can supply their own value via the `:tag` option.

A minor change was to move the trigger edge selection to an option. Most
people want notifications on both edges so that's the default with
`subscribe/2`.

The motivation behind this change is to support a mode where multiple
GPIOs can be opened with one handle. This creates some long GPIO specs
(lists of GPIO specs), and since values are no longer 0 or 1, knowing
the previous value became important. This commit includes the new
previous_value field.
