### PR TITLE
Support closing lost and forgotten GPIOs

### DIFF
--- a/c_src/gpio_nif.c
+++ b/c_src/gpio_nif.c
@@ -42,6 +42,35 @@ static void release_gpio_pin(struct gpio_priv *priv, struct gpio_pin *pin)
     }
 }
 
+static void register_gpio_pin(struct gpio_priv *priv, struct gpio_pin *pin)
+{
+    enif_mutex_lock(priv->gpio_pins_lock);
+    pin->next = priv->gpio_pins;
+    priv->gpio_pins = pin;
+    pin->registered = true;
+    enif_mutex_unlock(priv->gpio_pins_lock);
+}
+
+static void unregister_gpio_pin(struct gpio_priv *priv, struct gpio_pin *pin)
+{
+    enif_mutex_lock(priv->gpio_pins_lock);
+
+    if (pin->registered) {
+        struct gpio_pin **current = &priv->gpio_pins;
+
+        while (*current && *current != pin)
+            current = &(*current)->next;
+
+        if (*current == pin)
+            *current = pin->next;
+
+        pin->registered = false;
+        pin->next = NULL;
+    }
+
+    enif_mutex_unlock(priv->gpio_pins_lock);
+}
+
 // Reset the pin's environment to hold exactly the terms it needs. Without this,
 // repeated subscribe calls would accumulate copies in pin->env and grow it
 // without bound.
@@ -62,6 +91,7 @@ static void gpio_pin_dtor(ErlNifEnv *env, void *obj)
 
     debug("gpio_pin_dtor called on pin={%s,%d+%d}", pin->gpiochip, pin->offsets[0], pin->num_lines);
 
+    unregister_gpio_pin(priv, pin);
     release_gpio_pin(priv, pin);
 }
 
@@ -218,9 +248,19 @@ static int load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM info)
     }
 
     priv->gpio_pin_rt = enif_open_resource_type_x(env, "gpio_pin", &gpio_pin_init, ERL_NIF_RT_CREATE, NULL);
+    priv->gpio_pins_lock = enif_mutex_create("gpio_pins");
+    priv->gpio_pins = NULL;
+
+    if (!priv->gpio_pins_lock) {
+        error("Can't create GPIO pin lock");
+        enif_free(priv);
+        return 1;
+    }
 
     if (hal_load(&priv->hal_priv) < 0) {
         error("Can't initialize HAL");
+        enif_mutex_destroy(priv->gpio_pins_lock);
+        enif_free(priv);
         return 1;
     }
 
@@ -615,6 +655,8 @@ static ERL_NIF_TERM open_gpio(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     pin->gpio_spec = enif_make_copy(pin->env, argv[0]);
     pin->notify_id = 0;
     pin->notify_map = false;
+    pin->next = NULL;
+    pin->registered = false;
     pin->hal_priv = priv->hal_priv;
     pin->config.is_output = is_output;
     pin->config.trigger = TRIGGER_NONE;
@@ -629,6 +671,8 @@ static ERL_NIF_TERM open_gpio(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
         enif_release_resource(pin);
         return make_errno_error(env, rc);
     }
+
+    register_gpio_pin(priv, pin);
 
     // Transfer ownership of the resource to Erlang so that it can be garbage collected.
     ERL_NIF_TERM pin_resource = enif_make_resource(env, pin);
@@ -646,6 +690,41 @@ static ERL_NIF_TERM close_gpio(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv
         return enif_make_badarg(env);
 
     release_gpio_pin(priv, pin);
+
+    return atom_ok;
+}
+
+static bool pin_references_gpio(struct gpio_pin *pin, const char *gpiochip_path, int offset)
+{
+    if (strcmp(pin->gpiochip, gpiochip_path) != 0)
+        return false;
+
+    for (int i = 0; i < pin->num_lines; i++) {
+        if (pin->offsets[i] == offset)
+            return true;
+    }
+
+    return false;
+}
+
+static ERL_NIF_TERM force_close(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    struct gpio_priv *priv = enif_priv_data(env);
+    char gpiochip_path[MAX_GPIOCHIP_PATH_LEN];
+    int offset;
+
+    if (argc != 1 || !get_resolved_location(env, argv[0], gpiochip_path, &offset))
+        return enif_make_badarg(env);
+
+    enif_mutex_lock(priv->gpio_pins_lock);
+    for (struct gpio_pin *pin = priv->gpio_pins; pin; pin = pin->next) {
+        if (pin_references_gpio(pin, gpiochip_path, offset)) {
+            // Close the GPIO, but don't free up everything until the pin
+            // has been properly closed.
+            hal_close_gpio(pin);
+        }
+    }
+    enif_mutex_unlock(priv->gpio_pins_lock);
 
     return atom_ok;
 }
@@ -674,6 +753,7 @@ static ERL_NIF_TERM gpio_enumerate(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
 static ErlNifFunc nif_funcs[] = {
     {"open", 6, open_gpio, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"close", 1, close_gpio, 0},
+    {"force_close", 1, force_close, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"read", 1, read_gpio, 0},
     {"write", 2, write_gpio, 0},
     {"set_interrupts", 4, set_interrupts, 0},

--- a/c_src/gpio_nif.c
+++ b/c_src/gpio_nif.c
@@ -276,6 +276,8 @@ static void unload(ErlNifEnv *env, void *priv_data)
     debug("unload");
 
     hal_unload(&priv->hal_priv);
+    enif_mutex_destroy(priv->gpio_pins_lock);
+    enif_free(priv);
 }
 
 static ERL_NIF_TERM read_gpio(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])

--- a/c_src/gpio_nif.h
+++ b/c_src/gpio_nif.h
@@ -59,6 +59,8 @@ enum drive_mode {
 
 struct gpio_priv {
     ErlNifResourceType *gpio_pin_rt;
+    ErlNifMutex *gpio_pins_lock;
+    struct gpio_pin *gpio_pins;
 
     uint32_t hal_priv[1];
 };
@@ -112,6 +114,11 @@ struct gpio_pin {
     // true  -> subscribe map format using notify_id
     // false -> legacy set_interrupts tuple format using gpio_spec
     bool notify_map;
+
+    // Linked into gpio_priv.gpio_pins while the resource is alive. This lets
+    // force_close release handles even when their Erlang terms are unavailable.
+    struct gpio_pin *next;
+    bool registered;
 };
 
 // Atoms

--- a/lib/gpio.ex
+++ b/lib/gpio.ex
@@ -171,6 +171,8 @@ defmodule Circuits.GPIO do
   * `:initial_value` - the initial value of an output GPIO
   * `:pull_mode` - the initial pull mode for an input GPIO
   * `:drive_mode` - the drive mode of an output GPIO
+  * `:on_busy` - behavior when an open fails because the GPIO is already open;
+    `:error` returns the error (default), `:take_over` closes other references and retries.
   * `:force_enumeration` - Linux cdev-specific option to force a scan of
     available GPIOs rather than using the cache. This is only for test purposes
     since the GPIO cache should refresh as needed.
@@ -179,6 +181,7 @@ defmodule Circuits.GPIO do
           initial_value: value(),
           pull_mode: pull_mode(),
           drive_mode: drive_mode(),
+          on_busy: :take_over | :error,
           force_enumeration: boolean()
         ]
 
@@ -272,8 +275,29 @@ defmodule Circuits.GPIO do
   interpreted as an integer with the same one-bit-per-line layout, and
   `:pull_mode`/`:drive_mode` apply to every line in the group.
 
-  If you're having trouble, see `enumerate/0` for available GPIOs. If you
-  suspect a hardware or driver issue, see `Circuits.GPIO.Diagnostics`.
+  ## Exclusivity
+
+  Each GPIO may only have one open handle at a time. This is enforced by the
+  backend, so while one backend may support it, it's not guaranteed.  Library
+  authors should assume exclusivity on GPIOs to be cross platform.  In
+  practice, this isn't a big deal except when debugging.
+
+  Use the `:on_busy` option to `:take_over` a GPIO from another open handle
+  when it's busy. This is useful for `GenServer`s when they restart to avoid
+  waiting for the BEAMs GC to clean up the old handle. It's also handy when
+  experimenting at the IEx prompt when you lose a reference. The `:on_busy`
+  option only works for handles known to the running BEAM instance.
+
+  ## Troubleshooting
+
+  The most common issue is figuring out the names or labels on GPIOs. See
+  `enumerate/0` for available GPIOs. On Linux, labels are defined in the device
+  tree.
+
+  If you suspect a hardware or driver issue, see `Circuits.GPIO.Diagnostics`.
+
+  If you're getting `{:error, :already_open}`, try passing `on_busy: :take_over`
+  to try taking over the GPIO from a lost or outdated reference.
 
   Options:
 
@@ -283,6 +307,9 @@ defmodule Circuits.GPIO do
     input pin. `:not_set` is the default.
   * `:drive_mode` - Set to `:push_pull`, `:open_drain`, or `:open_source`.
     `:push_pull` is the default. Only used for outputs.
+  * `:on_busy` - Set to `:take_over` or `:error`. `:take_over` will try
+    closing other GPIO users to allow this call to succeed. Defaults to
+    `:error`.
 
   Returns `{:ok, handle}` on success.
   """
@@ -327,8 +354,25 @@ defmodule Circuits.GPIO do
       |> Keyword.put_new(:initial_value, 0)
       |> Keyword.put_new(:pull_mode, :not_set)
       |> Keyword.put_new(:drive_mode, :push_pull)
+      |> Keyword.put_new(:on_busy, :error)
 
-    backend.open(gpio_spec, direction, all_options)
+    case backend.open(gpio_spec, direction, all_options) do
+      {:error, :already_open} ->
+        take_over_and_retry(backend, gpio_spec, direction, all_options)
+
+      result ->
+        result
+    end
+  end
+
+  defp take_over_and_retry(backend, gpio_spec, direction, options) do
+    if Keyword.get(options, :on_busy) == :take_over do
+      with :ok <- force_close_specs(backend, List.wrap(gpio_spec), options) do
+        backend.open(gpio_spec, direction, options)
+      end
+    else
+      {:error, :already_open}
+    end
   end
 
   defp check_gpio_spec!(gpio_spec) do
@@ -345,11 +389,8 @@ defmodule Circuits.GPIO do
       length(specs) > 64 ->
         raise ArgumentError, "A GPIO group is limited to 64 lines"
 
-      not Enum.all?(specs, &gpio_spec?/1) ->
-        raise ArgumentError, "Invalid GPIO spec in #{inspect(specs)}"
-
       true ->
-        :ok
+        Enum.each(specs, &check_gpio_spec!/1)
     end
   end
 
@@ -392,6 +433,13 @@ defmodule Circuits.GPIO do
     check_options!(rest)
   end
 
+  defp check_options!([{:on_busy, value} | rest]) do
+    if value not in [:take_over, :error],
+      do: raise(ArgumentError, ":on_busy should be :take_over or :error")
+
+    check_options!(rest)
+  end
+
   defp check_options!([_unknown_option | rest]) do
     # Ignore unknown options - the backend might use them
     check_options!(rest)
@@ -405,6 +453,35 @@ defmodule Circuits.GPIO do
   """
   @spec close(Handle.t()) :: :ok
   defdelegate close(handle), to: Handle
+
+  @doc """
+  Close GPIO handles by gpio spec or identifier
+
+  This is useful when a process has lost its handles or when GPIO hardware is
+  being reconfigured. After this call, any use of the old file handles will
+  raise an exception.
+
+  See the `:on_busy` option in the `t:open_options/0` docs for automatically
+  taking over GPIOs when calling `open/3`.
+  """
+  @spec force_close(gpio_spec() | identifiers() | [gpio_spec() | identifiers()]) ::
+          :ok | {:error, atom()}
+  def force_close(gpio_specs) do
+    specs = gpio_specs |> List.wrap() |> Enum.map(&normalize_spec/1)
+    Enum.each(specs, &check_gpio_spec!/1)
+
+    {backend, backend_options} = default_backend()
+    force_close_specs(backend, specs, backend_options)
+  end
+
+  defp force_close_specs(backend, specs, options) do
+    Enum.reduce_while(specs, :ok, fn spec, :ok ->
+      case backend.force_close(spec, options) do
+        :ok -> {:cont, :ok}
+        error -> {:halt, error}
+      end
+    end)
+  end
 
   @doc """
   Read a GPIO's value

--- a/lib/gpio/backend.ex
+++ b/lib/gpio/backend.ex
@@ -80,6 +80,14 @@ defmodule Circuits.GPIO.Backend do
               {:ok, Handle.t()} | {:error, atom()}
 
   @doc """
+  Force all open handles that reference a GPIO spec to close
+  """
+  @callback force_close(
+              gpio_spec :: GPIO.gpio_spec(),
+              options :: GPIO.open_options()
+            ) :: :ok | {:error, atom()}
+
+  @doc """
   Return information about this backend
   """
   @callback backend_info() :: map()

--- a/lib/gpio/cdev.ex
+++ b/lib/gpio/cdev.ex
@@ -132,6 +132,13 @@ defmodule Circuits.GPIO.CDev do
     end
   end
 
+  @impl Backend
+  def force_close(gpio_spec, options) do
+    with {:ok, location} <- find_location(gpio_spec, options) do
+      Nif.force_close(resolve_gpiochip(location))
+    end
+  end
+
   defp resolve_group(specs, options) do
     resolved =
       Enum.reduce_while(specs, {:ok, []}, fn spec, {:ok, acc} ->

--- a/lib/gpio/gpio_nif.ex
+++ b/lib/gpio/gpio_nif.ex
@@ -19,6 +19,7 @@ defmodule Circuits.GPIO.Nif do
     do: :erlang.nif_error(:nif_not_loaded)
 
   def close(_gpio), do: :erlang.nif_error(:nif_not_loaded)
+  def force_close(_gpio), do: :erlang.nif_error(:nif_not_loaded)
   def read(_gpio), do: :erlang.nif_error(:nif_not_loaded)
   def write(_gpio, _value), do: :erlang.nif_error(:nif_not_loaded)
 

--- a/lib/gpio/nil_backend.ex
+++ b/lib/gpio/nil_backend.ex
@@ -32,6 +32,11 @@ defmodule Circuits.GPIO.NilBackend do
   end
 
   @impl Backend
+  def force_close(_gpio_spec, _options) do
+    {:error, :unimplemented}
+  end
+
+  @impl Backend
   def backend_info() do
     %{name: __MODULE__}
   end

--- a/test/circuits_gpio_test.exs
+++ b/test/circuits_gpio_test.exs
@@ -10,6 +10,42 @@ defmodule Circuits.GPIOTest do
   require Circuits.GPIO
   alias Circuits.GPIO
 
+  defmodule ForceCloseBackend do
+    @behaviour Circuits.GPIO.Backend
+
+    @impl true
+    def enumerate(_options), do: []
+
+    @impl true
+    def identifiers(_gpio_spec, _options), do: {:error, :not_found}
+
+    @impl true
+    def status(_gpio_spec, _options), do: {:error, :not_found}
+
+    @impl true
+    def open(_gpio_spec, _direction, _options) do
+      case Process.get(__MODULE__) do
+        {:force_closed, _gpio_specs} -> {:ok, :handle}
+        _ -> {:error, :already_open}
+      end
+    end
+
+    @impl true
+    def force_close(gpio_spec, _options) do
+      gpio_specs =
+        case Process.get(__MODULE__) do
+          {:force_closed, gpio_specs} -> [gpio_spec | gpio_specs]
+          _ -> [gpio_spec]
+        end
+
+      Process.put(__MODULE__, {:force_closed, gpio_specs})
+      :ok
+    end
+
+    @impl true
+    def backend_info, do: %{name: __MODULE__}
+  end
+
   doctest GPIO
 
   setup do
@@ -38,6 +74,47 @@ defmodule Circuits.GPIOTest do
     assert is_map(info)
     assert info.name == {Circuits.GPIO.CDev, [test: true]}
     assert info.pins_open == 0
+  end
+
+  describe "force_close/1" do
+    test "closes handles that reference GPIOs" do
+      {:ok, first} = GPIO.open({@gpiochip, 0}, :input)
+      {:ok, group} = GPIO.open([{@gpiochip, 1}, {@gpiochip, 2}], :input)
+      {:ok, last} = GPIO.open({@gpiochip, 3}, :input)
+
+      assert GPIO.backend_info().pins_open == 4
+
+      assert :ok = GPIO.force_close({@gpiochip, 1})
+      assert GPIO.backend_info().pins_open == 2
+
+      assert :ok = GPIO.force_close({@gpiochip, 2})
+      assert GPIO.backend_info().pins_open == 2
+
+      assert :ok = GPIO.force_close([{@gpiochip, 0}, {@gpiochip, 3}])
+      assert GPIO.backend_info().pins_open == 0
+
+      assert :ok = GPIO.close(first)
+      assert :ok = GPIO.close(group)
+      assert :ok = GPIO.close(last)
+    end
+
+    test "closing an empty list succeeds" do
+      assert :ok = GPIO.force_close([])
+    end
+
+    test "closed GPIOs raise when used" do
+      {:ok, gpio1} = GPIO.open({@gpiochip, 0}, :input)
+      assert :ok = GPIO.force_close({@gpiochip, 0})
+      # Raises :ebadf
+      assert_raise ErlangError, fn -> GPIO.read(gpio1) end
+
+      {:ok, gpio2} = GPIO.open({@gpiochip, 0}, :output)
+      assert :ok = GPIO.force_close({@gpiochip, 0})
+      assert_raise ErlangError, fn -> GPIO.write(gpio2, 0) end
+
+      assert :ok = GPIO.close(gpio1)
+      assert :ok = GPIO.close(gpio2)
+    end
   end
 
   describe "identifiers/2" do
@@ -221,6 +298,46 @@ defmodule Circuits.GPIOTest do
 
     GPIO.close(gpio)
     assert GPIO.backend_info().pins_open == 0
+  end
+
+  test "open does not force close GPIOs that open successfully" do
+    {:ok, previous} = GPIO.open({@gpiochip, 1}, :input)
+    {:ok, current} = GPIO.open({@gpiochip, 1}, :input)
+
+    assert GPIO.backend_info().pins_open == 2
+
+    GPIO.close(previous)
+    GPIO.close(current)
+  end
+
+  test "open retries after force closing an already open GPIO" do
+    original_backend = Application.get_env(:circuits_gpio, :default_backend)
+    Application.put_env(:circuits_gpio, :default_backend, {ForceCloseBackend, []})
+
+    on_exit(fn ->
+      if original_backend do
+        Application.put_env(:circuits_gpio, :default_backend, original_backend)
+      else
+        Application.delete_env(:circuits_gpio, :default_backend)
+      end
+    end)
+
+    Process.delete(ForceCloseBackend)
+    gpio_specs = [{@gpiochip, 1}, {@gpiochip, 2}]
+
+    assert GPIO.open(gpio_specs, :input, on_busy: :take_over) == {:ok, :handle}
+    assert Process.get(ForceCloseBackend) == {:force_closed, Enum.reverse(gpio_specs)}
+
+    Process.delete(ForceCloseBackend)
+    assert GPIO.open({@gpiochip, 1}, :input, on_busy: :error) == {:error, :already_open}
+
+    # Test default
+    Process.delete(ForceCloseBackend)
+    assert GPIO.open({@gpiochip, 1}, :input) == {:error, :already_open}
+
+    assert_raise ArgumentError, ":on_busy should be :take_over or :error", fn ->
+      GPIO.open({@gpiochip, 1}, :input, on_busy: :invalid)
+    end
   end
 
   test "open returns errors on invalid pins" do
@@ -720,6 +837,18 @@ defmodule Circuits.GPIOTest do
     assert GPIO.read_one({@gpiochip, 0}) == 0
     assert GPIO.write_one({@gpiochip, 1}, 1) == :ok
     assert GPIO.read_one({@gpiochip, 0}) == 1
+  end
+
+  test "read_one/2 and write_one/3 do not force close GPIOs that open successfully" do
+    {:ok, read_handle} = GPIO.open({@gpiochip, 0}, :input)
+    assert GPIO.read_one({@gpiochip, 0}) == 0
+    assert GPIO.backend_info().pins_open == 1
+    GPIO.close(read_handle)
+
+    {:ok, write_handle} = GPIO.open({@gpiochip, 1}, :input)
+    assert GPIO.write_one({@gpiochip, 1}, 1) == :ok
+    assert GPIO.backend_info().pins_open == 1
+    GPIO.close(write_handle)
   end
 
   describe "groups" do


### PR DESCRIPTION
Exclusive GPIO ownership causes issues when experimenting and when
recovering when GC hasn't cleaned up an old reference. This adds
`Circuits.GPIO.force_close/1` to close GPIOs by their gpio spec or
identifier. It also adds an `open/3` option to automatically close a
GPIO if its busy.
